### PR TITLE
Parse, render multi-paragraph footnotes.

### DIFF
--- a/lib/earmark/block.ex
+++ b/lib/earmark/block.ex
@@ -246,7 +246,12 @@ defmodule Earmark.Block do
     {para_lines, rest} = Enum.split_while(rest, &is_text/1)
     first_line = %Line.Text{line: defn.content}
     para = parse([ first_line | para_lines ], [])
-    parse( rest, [ %FnDef{id: defn.id, blocks: para } | result ] )
+    {indent_lines, rest} = Enum.split_while(rest, &is_indent_or_blank/1)
+    {blocks, _ } = remove_trailing_blank_lines(indent_lines)
+                |> Enum.map(&(properly_indent(&1, 1)))
+                |> Parser.parse(true)
+    blocks = Enum.concat(para, blocks)
+    parse( rest, [ %FnDef{id: defn.id, blocks: blocks } | result ] )
   end
 
   ####################

--- a/lib/earmark/html_renderer.ex
+++ b/lib/earmark/html_renderer.ex
@@ -124,15 +124,29 @@ defmodule Earmark.HtmlRenderer do
 
   def render_block(%Block.FnList{blocks: footnotes}, context, mf) do
     items = Enum.map(footnotes, fn(note) ->
-      [last_block | blocks] = Enum.reverse(note.blocks)
-      [last_line | lines] = Enum.reverse(last_block.lines)
-      last_line = ~s[#{last_line}&nbsp;<a href="#fnref:#{note.number}" title="return to article" class="reversefootnote">&#x21A9;</a>]
-      last_block = put_in(last_block.lines, Enum.reverse([last_line | lines]))
-      blocks = Enum.reverse([last_block | blocks])
+      blocks = append_footnote_link(note)
       %Block.ListItem{attrs: "#fn:#{note.number}", type: :ol, blocks: blocks}
     end)
     html = render_block(%Block.List{type: :ol, blocks: items}, context, mf)
     Enum.join([~s[<div class="footnotes">], "<hr>", html, "</div>"], "\n")
+  end
+
+  def append_footnote_link(note=%Block.FnDef{}) do
+    fnlink = ~s[<a href="#fnref:#{note.number}" title="return to article" class="reversefootnote">&#x21A9;</a>]
+    [ last_block | blocks ] = Enum.reverse(note.blocks)
+    last_block = append_footnote_link(last_block, fnlink)
+    Enum.reverse([last_block | blocks])
+    |> List.flatten
+  end
+
+  def append_footnote_link(block=%Block.Para{lines: lines}, fnlink) do
+    [ last_line | lines ] = Enum.reverse(block.lines)
+    last_line = "#{last_line}&nbsp;#{fnlink}"
+    [put_in(block.lines, Enum.reverse([last_line | lines]))]
+  end
+
+  def append_footnote_link(block, fnlink) do
+    [block, %Block.Para{lines: fnlink}]
   end
 
   ####################

--- a/lib/earmark/html_renderer.ex
+++ b/lib/earmark/html_renderer.ex
@@ -131,24 +131,6 @@ defmodule Earmark.HtmlRenderer do
     Enum.join([~s[<div class="footnotes">], "<hr>", html, "</div>"], "\n")
   end
 
-  def append_footnote_link(note=%Block.FnDef{}) do
-    fnlink = ~s[<a href="#fnref:#{note.number}" title="return to article" class="reversefootnote">&#x21A9;</a>]
-    [ last_block | blocks ] = Enum.reverse(note.blocks)
-    last_block = append_footnote_link(last_block, fnlink)
-    Enum.reverse([last_block | blocks])
-    |> List.flatten
-  end
-
-  def append_footnote_link(block=%Block.Para{lines: lines}, fnlink) do
-    [ last_line | lines ] = Enum.reverse(block.lines)
-    last_line = "#{last_line}&nbsp;#{fnlink}"
-    [put_in(block.lines, Enum.reverse([last_line | lines]))]
-  end
-
-  def append_footnote_link(block, fnlink) do
-    [block, %Block.Para{lines: fnlink}]
-  end
-
   ####################
   # IDDef is ignored #
   ####################
@@ -247,4 +229,27 @@ defmodule Earmark.HtmlRenderer do
   def add_to(attrs, text) do
     Regex.replace(~r/>/, text, " #{attrs}>", global: false)
   end
+
+  ###############################
+  # Append Footnote Return Link #
+  ###############################
+
+  def append_footnote_link(note=%Block.FnDef{}) do
+    fnlink = ~s[<a href="#fnref:#{note.number}" title="return to article" class="reversefootnote">&#x21A9;</a>]
+    [ last_block | blocks ] = Enum.reverse(note.blocks)
+    last_block = append_footnote_link(last_block, fnlink)
+    Enum.reverse([last_block | blocks])
+    |> List.flatten
+  end
+
+  def append_footnote_link(block=%Block.Para{lines: lines}, fnlink) do
+    [ last_line | lines ] = Enum.reverse(lines)
+    last_line = "#{last_line}&nbsp;#{fnlink}"
+    [put_in(block.lines, Enum.reverse([last_line | lines]))]
+  end
+
+  def append_footnote_link(block, fnlink) do
+    [block, %Block.Para{lines: fnlink}]
+  end
+
 end

--- a/test/footnote_test.exs
+++ b/test/footnote_test.exs
@@ -46,6 +46,55 @@ defmodule FootnoteTest do
     assert result == expected
   end
 
+  test "handles multi-paragraph footnote bodies" do
+    lines = ["This is a footnote[^fn-1]",
+             "",
+             "[^fn-1]: line 1",
+             "line 2",
+             "",
+             "    Para 2 line 1",
+             "    Para 2 line 2",
+             "",
+             "    * List Item 1",
+             "      List Item 1 Cont",
+             "    * List Item 2"
+             ]
+    {result, _} = Parser.parse(lines)
+    expected = [%Block.Para{lines: ["This is a footnote[^fn-1]"]},
+                %Block.FnDef{id: "fn-1", blocks: [%Block.Para{lines: ["line 1", "line 2"]},
+                                                  %Block.Para{lines: ["Para 2 line 1", "Para 2 line 2"]},
+                                                  %Block.List{blocks: [
+                                                      %Block.ListItem{blocks: [%Block.Para{lines: ["List Item 1", "  List Item 1 Cont"]}], spaced: false},
+                                                      %Block.ListItem{blocks: [%Block.Para{lines: ["List Item 2"]}], spaced: false}
+                                                      ]}
+                                                  ]}]
+    assert result == expected
+    html = Earmark.to_html(lines, put_in(%Earmark.Options{}.footnotes, true))
+    expected_html = """
+    <p>This is a footnote<a href="#fn:1" id="fnref:1" class="footnote" title="see footnote">1</a></p>
+    <div class="footnotes">
+    <hr>
+    <ol>
+    <li id="fn:1"><p>line 1
+    line 2</p>
+    <p>Para 2 line 1
+    Para 2 line 2</p>
+    <ul>
+    <li>List Item 1
+      List Item 1 Cont
+    </li>
+    <li>List Item 2
+    </li>
+    </ul>
+    <p><a href="#fnref:1" title="return to article" class="reversefootnote">&#x21A9;</a></p>
+    </li>
+    </ol>
+
+    </div>
+    """
+    assert "#{html}\n" == expected_html
+  end
+
   test "uses a starting footnote number" do
     para = %Block.Para{lines: ["line 1[^ref-1] and", "line 2[^ref-2]."]}
     text = [para,


### PR DESCRIPTION
Parsing: FnDef will greedily grab all following indented code.  As far as I can
tell, this conforms to the behavior of pandoc and multimarkdown.

Rendering: If the final block in the footnote is a paragraph, the "return to
article" link will render in that paragraph.  Otherwise, a new paragraph is
appended to the footnote containing the return link.  This mimics pandoc's
behavior -- multimarkdown will append it to the last paragraph of the footnote,
regardless of what follows.