### PR TITLE
Fix hr rendering

### DIFF
--- a/lib/earmark/html_renderer.ex
+++ b/lib/earmark/html_renderer.ex
@@ -33,15 +33,15 @@ defmodule Earmark.HtmlRenderer do
   # Ruler #
   #########
   def render_block(%Block.Ruler{type: "-", attrs: attrs}, _context, _mf) do
-    add_attrs(~S{<hr/>\n}, attrs, [{"class", ["thin"]}])
+    add_attrs("<hr/>\n", attrs, [{"class", ["thin"]}])
   end
   
   def render_block(%Block.Ruler{type: "_", attrs: attrs}, _context, _mf) do
-    add_attrs(~S{<hr/>\n}, attrs, [{"class", ["medium"]}])
+    add_attrs("<hr/>\n", attrs, [{"class", ["medium"]}])
   end
 
   def render_block(%Block.Ruler{type: "*", attrs: attrs}, _context, _mf) do
-    add_attrs(~S{<hr/>\n}, attrs, [{"class", ["thick"]}])
+    add_attrs("<hr/>\n", attrs, [{"class", ["thick"]}])
   end
 
   ###########


### PR DESCRIPTION
Earmark renders hr with escaped `\n` at the end and produce extra symbols [in html](http://artemeff.com/exredis/README.html):

``` elixir
Earmark.to_html("---")
# => "<hr/ class=\"thin\">\\n"
```

I'm fix it:

``` elixir
Earmark.to_html("---")
# => "<hr/ class=\"thin\">\n"
```
