### PR TITLE
Remove unecessary escapes and use faster String.replace when possible

### DIFF
--- a/lib/earmark/helpers.ex
+++ b/lib/earmark/helpers.ex
@@ -54,15 +54,15 @@ defmodule Earmark.Helpers do
 
   def escape(html, encode \\ false)
 
-  def escape(html, false), do: _escape(Regex.replace(~r{&(?!#?\w+;)}, html, "\\&amp;"))
-  def escape(html, _), do: _escape(Regex.replace(~r{&}, html, "\\&amp;"))
+  def escape(html, false), do: _escape(Regex.replace(~r{&(?!#?\w+;)}, html, "&amp;"))
+  def escape(html, _), do: _escape(String.replace(html, "&", "&amp;"))
                                                   
   defp _escape(html) do
     html
-    |> replace(~r/</,  "\\&lt;")
-    |> replace(~r/>/,  "\\&gt;")
-    |> replace(~r/\"/, "\\&quot;")
-    |> replace(~r/"/,  "\\&#39;")
+    |> String.replace("<",  "&lt;")
+    |> String.replace(">",  "&gt;")
+    |> String.replace("\"", "&quot;")
+    |> String.replace("'",  "&#39;")
   end
 
   @doc """

--- a/lib/earmark/html_renderer.ex
+++ b/lib/earmark/html_renderer.ex
@@ -239,6 +239,6 @@ defmodule Earmark.HtmlRenderer do
   end                            
 
   def add_to(attrs, text) do
-    Regex.replace(~r/>/, text, " #{attrs}>", global: false)
+    String.replace(text, ">", " #{attrs}>", global: false)
   end
 end


### PR DESCRIPTION
With Elixir v1.1, we fixed a bug in Regex.replace where `\\` were being silently discarded, and this made some earmark usage fail. This commit fixes that.

@pragdave if you could release a new version after merging and verifying this fix, I would really appreciate it! :D