### PR TITLE
fix markdown file extension in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 
 
+
 <!-- moduledoc: Earmark -->
 
 # Earmark—A Pure Elixir Markdown Processor
@@ -24,7 +25,7 @@
 ### Command line
 
     $ mix escript.build
-    $ ./earmark file.ms
+    $ ./earmark file.md
 
 ## Supports
 
@@ -123,6 +124,7 @@ Copyright © 2014 Dave Thomas, The Pragmatic Programmers
 @/+pragdave,  dave@pragprog.com
 
 Licensed under the same terms as Elixir.
+
 
 
 

--- a/lib/earmark.ex
+++ b/lib/earmark.ex
@@ -21,7 +21,7 @@ defmodule Earmark do
   ### Command line
 
       $ mix escript.build
-      $ ./earmark file.ms
+      $ ./earmark file.md
 
   ## Supports
 

--- a/tasks/readme.exs
+++ b/tasks/readme.exs
@@ -100,7 +100,7 @@ defmodule Mix.Tasks.Readme do
       (case File.write("README.md", readme) do
         :ok -> "README.md updated"
         {:error, reason} ->
-           "README.ms: #{:file.explain_error(reason)}"
+           "README.md: #{:file.explain_error(reason)}"
       end)
   end
 end


### PR DESCRIPTION
I think you meant `.md` instead of `.ms`