### PR TITLE
Support strikethrough

### DIFF
--- a/lib/earmark/html_renderer.ex
+++ b/lib/earmark/html_renderer.ex
@@ -149,10 +149,11 @@ defmodule Earmark.HtmlRenderer do
   # And here are the inline renderers #
   #####################################
 
-  def br,             do: "<br/>"
-  def codespan(text), do: ~s[<code class="inline">#{text}</code>]
-  def em(text),       do: "<em>#{text}</em>"
-  def strong(text),   do: "<strong>#{text}</strong>"
+  def br,                  do: "<br/>"
+  def codespan(text),      do: ~s[<code class="inline">#{text}</code>]
+  def em(text),            do: "<em>#{text}</em>"
+  def strong(text),        do: "<strong>#{text}</strong>"
+  def strikethrough(text), do: "<del>#{text}</del>
 
   def link(url, text),        do: ~s[<a href="#{url}">#{text}</a>]
   def link(url, text, nil),   do: ~s[<a href="#{url}">#{text}</a>]

--- a/lib/earmark/html_renderer.ex
+++ b/lib/earmark/html_renderer.ex
@@ -153,7 +153,7 @@ defmodule Earmark.HtmlRenderer do
   def codespan(text),      do: ~s[<code class="inline">#{text}</code>]
   def em(text),            do: "<em>#{text}</em>"
   def strong(text),        do: "<strong>#{text}</strong>"
-  def strikethrough(text), do: "<del>#{text}</del>
+  def strikethrough(text), do: "<del>#{text}</del>"
 
   def link(url, text),        do: ~s[<a href="#{url}">#{text}</a>]
   def link(url, text, nil),   do: ~s[<a href="#{url}">#{text}</a>]

--- a/test/inline_test.ex
+++ b/test/inline_test.ex
@@ -99,6 +99,11 @@ defmodule InlineTest do
     result = convert_pedantic("hello \\*world\\*")
     assert result == "hello *world*"
   end
+  
+  test "tilde mean strikethrough" do
+    result = convert_gfm("this ~~not this~~")
+    assert result == "this <del>not this</del>"
+  end
 
   ########
   # Code #


### PR DESCRIPTION
Hey Dave,

looks like we [support strikethrough](https://github.com/pragdave/earmark/blob/eab68a62d41c789404eb007bb746d3956f769088/lib/earmark/inline.ex#L89-L93) but there is no `HtmlRenderer` function for it. That results in a runtime error.

This PR should rectify that.

Thanks!