### PR TITLE
Validate html links

### DIFF
--- a/lib/earmark/helpers.ex
+++ b/lib/earmark/helpers.ex
@@ -47,6 +47,16 @@ defmodule Earmark.Helpers do
   end
 
   @doc """
+  Encode URIs to be included in the `<a>` elements.
+
+  Percent-escapes a URI, and after that escapes any
+  `&`, `<`, `>`, `"`, `'`.
+  """
+  def encode(html) do
+    URI.encode(html) |> escape(true)
+  end
+
+  @doc """
   Replace <, >, and quotes with the corresponding entities. If
   `encode` is true, convert ampersands, too, otherwise only
    convert non-entity ampersands. 

--- a/lib/earmark/inline.ex
+++ b/lib/earmark/inline.ex
@@ -6,9 +6,7 @@ defmodule Earmark.Inline do
   """
   
   import Earmark.Helpers
-
   alias Earmark.Context
-
 
   @doc false
   def convert(src, context) when is_list(src) do  
@@ -143,11 +141,11 @@ defmodule Earmark.Inline do
     link = (if String.at(link, 6) == ":", do: behead(link, 7), else: link)
     text = mangle_link(link)
     href = mangle_link("mailto:") <> text
-    { href, text }
+    { URI.encode(href), escape(text) }
   end
 
   defp convert_autolink(link, _separator) do
-    link = escape(link)
+    link = URI.encode(link)
     { link, link }
   end
 
@@ -182,19 +180,19 @@ defmodule Earmark.Inline do
   end
 
   defp output_link(context, text, href, title) do
-    href = escape(href)
+    href = URI.encode(href)
     title = if title, do: escape(title), else: nil
     context.options.renderer.link(href, convert_each(text, context, []), title)
   end
 
   defp output_footnote_link(context, ref, back_ref, number) do
-    ref = escape(ref)
-    back_ref = escape(back_ref)
+    ref = URI.encode(ref)
+    back_ref = URI.encode(back_ref)
     context.options.renderer.footnote_link(ref, back_ref, number)
   end
 
   defp output_image(renderer, text, href, title) do
-    href = escape(href)
+    href = URI.encode(href)
     title = if title, do: escape(title), else: nil
     renderer.image(href, escape(text), title)
   end

--- a/lib/earmark/inline.ex
+++ b/lib/earmark/inline.ex
@@ -141,11 +141,11 @@ defmodule Earmark.Inline do
     link = (if String.at(link, 6) == ":", do: behead(link, 7), else: link)
     text = mangle_link(link)
     href = mangle_link("mailto:") <> text
-    { URI.encode(href), escape(text) }
+    { encode(href), escape(text) }
   end
 
   defp convert_autolink(link, _separator) do
-    link = URI.encode(link)
+    link = encode(link)
     { link, link }
   end
 
@@ -180,19 +180,19 @@ defmodule Earmark.Inline do
   end
 
   defp output_link(context, text, href, title) do
-    href = URI.encode(href)
+    href = encode(href)
     title = if title, do: escape(title), else: nil
     context.options.renderer.link(href, convert_each(text, context, []), title)
   end
 
   defp output_footnote_link(context, ref, back_ref, number) do
-    ref = URI.encode(ref)
-    back_ref = URI.encode(back_ref)
+    ref = encode(ref)
+    back_ref = encode(back_ref)
     context.options.renderer.footnote_link(ref, back_ref, number)
   end
 
   defp output_image(renderer, text, href, title) do
-    href = URI.encode(href)
+    href = encode(href)
     title = if title, do: escape(title), else: nil
     renderer.image(href, escape(text), title)
   end

--- a/test/regressions_test.exs
+++ b/test/regressions_test.exs
@@ -133,9 +133,9 @@ defmodule RegressionsTest do
     <pre><code class="elixir">term &lt; term :: boolean</code></pre>
     """
 
-    result = Earmark.to_html @code_inline_to_validate
+    result = Earmark.to_html "[&expr/1](http://elixir-lang.org/docs/master/elixir/Kernel.SpecialForms.htm#&expr/1)"
     assert result == """
-    <p><code class="inline">term &lt; term :: boolean</code></p>
+    <p><a href="http://elixir-lang.org/docs/master/elixir/Kernel.SpecialForms.htm#&amp;expr/1">&amp;expr/1</a></p>
     """
   end
 end

--- a/test/regressions_test.exs
+++ b/test/regressions_test.exs
@@ -106,4 +106,36 @@ defmodule RegressionsTest do
                      &quot;Hello &amp;lt;world&amp;gt;&quot;</code></pre>
                      """
   end
+
+
+  @url_to_validate """
+  [<<>>/1](http://elixir-lang.org/docs/master/elixir/Kernel.SpecialForms.htm#<<>>/1)
+  """
+
+  @code_block_to_validate """
+  ```elixir
+  term < term :: boolean
+  ```
+  """
+
+  @code_inline_to_validate """
+  `term < term :: boolean`
+  """
+
+  test"Escape html in text different than in url" do
+    result = Earmark.to_html @url_to_validate
+    assert result == """
+    <p><a href="http://elixir-lang.org/docs/master/elixir/Kernel.SpecialForms.htm#%3C%3C%3E%3E/1">&lt;&lt;&gt;&gt;/1</a></p>
+    """
+
+    result = Earmark.to_html @code_block_to_validate
+    assert result == """
+    <pre><code class="elixir">term &lt; term :: boolean</code></pre>
+    """
+
+    result = Earmark.to_html @code_inline_to_validate
+    assert result == """
+    <p><code class="inline">term &lt; term :: boolean</code></p>
+    """
+  end
 end

--- a/test/table_test.exs
+++ b/test/table_test.exs
@@ -67,15 +67,15 @@ defmodule TableTest do
     expected = """
     <table>
     <colgroup>
-    <col align="left">
-    <col align="left">
-    <col align="left">
+    <col>
+    <col>
+    <col>
     </colgroup>
     <tr>
-    <td>a</td><td>b</td><td>c</td>
+    <td style="text-align: left">a</td><td style="text-align: left">b</td><td style="text-align: left">c</td>
     </tr>
     <tr>
-    <td>d</td><td>e</td><td>f</td>
+    <td style="text-align: left">d</td><td style="text-align: left">e</td><td style="text-align: left">f</td>
     </tr>
     </table>
     """
@@ -87,17 +87,17 @@ defmodule TableTest do
     expected = """
     <table>
     <colgroup>
-    <col align="left">
-    <col align="center">
-    <col align="right">
+    <col>
+    <col>
+    <col>
     </colgroup>
     <thead>
     <tr>
-    <th>a</th><th>b</th><th>c</th>
+    <th style="text-align: left">a</th><th style="text-align: center">b</th><th style="text-align: right">c</th>
     </tr>
     </thead>
     <tr>
-    <td>d</td><td>e</td><td>f</td>
+    <td style="text-align: left">d</td><td style="text-align: center">e</td><td style="text-align: right">f</td>
     </tr>
     </table>
     """
@@ -109,15 +109,15 @@ defmodule TableTest do
     expected = """
     <table>
     <colgroup>
-    <col align="left">
-    <col align="left">
-    <col align="left">
+    <col>
+    <col>
+    <col>
     </colgroup>
     <tr>
-    <td>a</td><td><em>b</em></td><td><code class="inline">c</code></td>
+    <td style="text-align: left">a</td><td style="text-align: left"><em>b</em></td><td style="text-align: left"><code class="inline">c</code></td>
     </tr>
     <tr>
-    <td><xx>d</xx></td><td><strong>e</strong></td><td><strong>f</strong></td>
+    <td style="text-align: left"><xx>d</xx></td><td style="text-align: left"><strong>e</strong></td><td style="text-align: left"><strong>f</strong></td>
     </tr>
     </table>
     """


### PR DESCRIPTION
This commit fixes everything we need in ExDoc to generate valid htmls.

1. `<COL ALIGN>` has been dropped in HTML5, so I moved the align as a style. I'm not sure if you want them in the table headings, but i just added them, just in case.

2. the other important change, is the way the HREF in anchor was being escaped. that was not valid html. & were being escaped incorrectly, such as `<` `>`.but the function `escape` should be used for text, but not for links. you can see that in the regeression tests

let me know what you think,
cheers

