### PR TITLE
Fix warning in Elixir 1.2

### DIFF
--- a/lib/earmark/inline.ex
+++ b/lib/earmark/inline.ex
@@ -306,6 +306,6 @@ defmodule Earmark.Inline do
       rule_updates = Keyword.merge(rule_updates, [footnote: ~r{\z\A}]) #noop
     end
     Keyword.merge(basic_rules, rule_updates)
-    |> Enum.into %{}
+    |> Enum.into(%{})
   end
 end


### PR DESCRIPTION
Please release a new version to hex.pm after merging this, we're trying to get all our dependencies ready for 1.2. Thanks!