### PR TITLE
Fix HtmlOneLine detection

### DIFF
--- a/lib/earmark/line.ex
+++ b/lib/earmark/line.ex
@@ -119,7 +119,7 @@ defmodule Earmark.Line do
       (match = Regex.run(~r{^<hr(\s|>|/).*}, line)) && !recursive ->
         %HtmlOneLine{tag: "hr", content: line}
 
-      (match = Regex.run(~r{^<([-\w]+?)>.*</\1>}, line)) && !recursive ->
+      (match = Regex.run(~r{^<([-\w]+?)(?:\s.*)?>.*</\1>}, line)) && !recursive ->
         [ _, tag ] = match
         %HtmlOneLine{tag: tag, content: line}
 

--- a/test/line_test.exs
+++ b/test/line_test.exs
@@ -79,6 +79,8 @@ defmodule LineTest do
      { "<hr/>",             %Line.HtmlOneLine{tag: "hr", content: "<hr/>"} },
      { "<hr class='a'>",    %Line.HtmlOneLine{tag: "hr", content: "<hr class='a'>"} },
 
+     { "<h2>Headline</h2>",               %Line.HtmlOneLine{tag: "h2", content: "<h2>Headline</h2>"} },
+     { "<h2 id='headline'>Headline</h2>", %Line.HtmlOneLine{tag: "h2", content: "<h2 id='headline'>Headline</h2>"} },
 
      { id1, %Line.IdDef{id: "ID1", url: "http://example.com", title: "The title"} },
      { id2, %Line.IdDef{id: "ID2", url: "http://example.com", title: "The title"} },


### PR DESCRIPTION
The combination of recent versions of ExDoc (probably since commit [ed8fc74](https://github.com/elixir-lang/ex_doc/commit/ed8fc74#diff-fc9775865b82e656523d7cbbe16526d2R137) there) and Earmark (`~> 0.2`) is broken.

### Broken Content

Suspect one has the following Markdown file to be processed by ExDoc:

    # Headline

    ## ExDoc Pre-Parsed

    ```elixir
    Broken.code()
    ```

Internally this is what will be given to Earmark for actual conversion:

```elixir
Earmark.to_html([
  "# Headline",
  "",
  "<h2 id=\"exdoc-pre-parsed\"> ExDoc Pre-Parsed</h2>",
  "",
   "```elixir", 
  "Broken.code()",
   "```"
])
```

The interesting part is the pre-rendered `<h2>` headline with the `id` attribute.

### What is broken?

Passing above content to Earmark results in some `Failed to find closing tag: <h2>` messages and ultimately an more or less unconverted page. Like, everything after the first `<h2>` will not get converted anymore.

Since commit [`716c81b`](https://github.com/pragdave/earmark/commit/716c81b#diff-9d41fe8c539de5536eb21cdcddb0d82bR127) the line containing the `<h2>` is not treated as a pure TextLine anymore, but matches the regex for an `HtmlOpenTag`. But as the closing tag is on the same line it will never be found and result in mentioned errors.

The first commit of this pull request (`776ee94`) should demonstrate this issue.

### How to fix?

Quite simple actually. Just allow the regex used to detect `HtmlOneLine` match attributes like `HtmlOpenTag`.

The second commit of this pull request (`3c4dbda`) does exactly that.