### PR TITLE
Adjusting fence block parsing

### DIFF
--- a/lib/earmark/line.ex
+++ b/lib/earmark/line.ex
@@ -112,7 +112,7 @@ defmodule Earmark.Line do
         [ _, spaces, code ] = match
         %Indent{level: div(String.length(spaces), 4), content: code }
 
-      match = Regex.run(~r/^\s*(```|~~~)\s*([A-Za-z0-9_\-]*)\s*$/, line) ->
+      match = Regex.run(~r/^\s*(```|~~~)\s*([\w\-]*)\s*$/u, line) ->
         [ _, fence, language ] = match
         %Fence{delimiter: fence, language: language}
 

--- a/lib/earmark/line.ex
+++ b/lib/earmark/line.ex
@@ -112,7 +112,7 @@ defmodule Earmark.Line do
         [ _, spaces, code ] = match
         %Indent{level: div(String.length(spaces), 4), content: code }
 
-      match = Regex.run(~r/^\s*(```|~~~)\s*(\w*)\s*$/, line) ->
+      match = Regex.run(~r/^\s*(```|~~~)\s*([A-Za-z0-9_\-]*)\s*$/, line) ->
         [ _, fence, language ] = match
         %Fence{delimiter: fence, language: language}
 

--- a/test/line_test.exs
+++ b/test/line_test.exs
@@ -61,12 +61,14 @@ defmodule LineTest do
      { " ``` java", %Line.Fence{delimiter: "```", language: "java", line: " ``` java"} },
      { "```java",  %Line.Fence{delimiter: "```", language: "java", line: "```java"} },
      { "```language-java",  %Line.Fence{delimiter: "```", language: "language-java"} },
+     { "```language-élixir",  %Line.Fence{delimiter: "```", language: "language-élixir"} },
 
      { "~~~",      %Line.Fence{delimiter: "~~~", language: "",     line: "~~~"} },
      { "~~~ java", %Line.Fence{delimiter: "~~~", language: "java", line: "~~~ java"} },
      { "~~~ java", %Line.Fence{delimiter: "~~~", language: "java", line: "~~~ java"} },
      { "  ~~~java",  %Line.Fence{delimiter: "~~~", language: "java", line: "  ~~~java"} },
      { "~~~ language-java", %Line.Fence{delimiter: "~~~", language: "language-java"} },
+     { "~~~ language-élixir",  %Line.Fence{delimiter: "~~~", language: "language-élixir"} },
 
      { "``` hello ```", %Line.Text{content: "``` hello ```"} },
      { "```hello```", %Line.Text{content: "```hello```"} },

--- a/test/line_test.exs
+++ b/test/line_test.exs
@@ -60,10 +60,13 @@ defmodule LineTest do
      { "``` java", %Line.Fence{delimiter: "```", language: "java", line: "``` java"} },
      { " ``` java", %Line.Fence{delimiter: "```", language: "java", line: " ``` java"} },
      { "```java",  %Line.Fence{delimiter: "```", language: "java", line: "```java"} },
+     { "```language-java",  %Line.Fence{delimiter: "```", language: "language-java"} },
+
      { "~~~",      %Line.Fence{delimiter: "~~~", language: "",     line: "~~~"} },
      { "~~~ java", %Line.Fence{delimiter: "~~~", language: "java", line: "~~~ java"} },
      { "~~~ java", %Line.Fence{delimiter: "~~~", language: "java", line: "~~~ java"} },
      { "  ~~~java",  %Line.Fence{delimiter: "~~~", language: "java", line: "  ~~~java"} },
+     { "~~~ language-java", %Line.Fence{delimiter: "~~~", language: "language-java"} },
 
      { "``` hello ```", %Line.Text{content: "``` hello ```"} },
      { "```hello```", %Line.Text{content: "```hello```"} },


### PR DESCRIPTION
This change allows the parsing of a language token in a fenced block that has hyphens in its name.  

This allows the recommendation in the html 5 spec to be fulfilled when rendering the output as html. 

See https://www.w3.org/TR/html5/text-level-semantics.html#the-code-element for details.