### PR TITLE
Fix unsafe conditional variables

### DIFF
--- a/lib/earmark.ex
+++ b/lib/earmark.ex
@@ -206,9 +206,10 @@ defmodule Earmark do
     if options.footnotes do
       { blocks, footnotes } = Earmark.Parser.handle_footnotes(blocks, options, mapper)
       context = put_in(context.footnotes, footnotes)
+      { blocks, context }
+    else
+      { blocks, context }
     end
-
-    { blocks, context }
   end
   def parse(lines, options) when is_binary(lines) do
     lines |> string_to_list |> parse(options)

--- a/lib/earmark/block.ex
+++ b/lib/earmark/block.ex
@@ -178,7 +178,7 @@ defmodule Earmark.Block do
     {code_lines, rest} = Enum.split_while(rest, fn (line) ->
       !match?(%Line.Fence{delimiter: ^delimiter, language: _}, line)
     end)
-    unless length(rest) == 0, do: rest = tl(rest)
+    rest = if length(rest) == 0, do: rest, else: tl(rest)
     code = (for line <- code_lines, do: line.line)
     parse(rest, [ %Code{lines: code, language: language} | result ])
   end
@@ -212,9 +212,10 @@ defmodule Earmark.Block do
     {html_lines, rest} = Enum.split_while(lines, fn (line) ->
       !(line.line =~ ~r/-->/)
     end)
-    unless length(rest) == 0 do
-      html_lines = html_lines ++ [ hd(rest) ]
-      rest = tl(rest)
+    {html_lines, rest} = if length(rest) == 0 do
+      {html_lines, rest}
+    else
+      {html_lines ++ [ hd(rest) ], tl(rest)}
     end
     html = (for line <- html_lines, do: line.line)
     parse(rest, [ %HtmlOther{html: html} | result ])

--- a/lib/earmark/helpers.ex
+++ b/lib/earmark/helpers.ex
@@ -5,9 +5,10 @@ defmodule Earmark.Helpers do
   """
   def expand_tabs(line) do
     if String.contains?(line, "\t") do
-      line = Regex.replace(~r{(.*?)\t}, line, &expander/2)
+      Regex.replace(~r{(.*?)\t}, line, &expander/2)
+    else
+      line
     end
-    line
   end
 
   defp expander(_, leader) do

--- a/lib/earmark/html_renderer.ex
+++ b/lib/earmark/html_renderer.ex
@@ -76,10 +76,12 @@ defmodule Earmark.HtmlRenderer do
     cols = for _align <- aligns, do: "<col>\n"
     html = [ add_attrs("<table>\n", attrs), "<colgroup>\n", cols, "</colgroup>\n" ]
 
-    if header do
+    html = if header do
       html = [ html, "<thead>\n",
                add_table_rows(context, [header], "th", aligns),
                "</thead>\n" ]
+    else
+      html
     end
 
     html = [ html, add_table_rows(context, rows, "td", aligns), "</table>\n" ]

--- a/lib/earmark/inline.ex
+++ b/lib/earmark/inline.ex
@@ -277,9 +277,8 @@ defmodule Earmark.Inline do
   end
 
   defp rules_for(options) do
-    rule_updates = []
-    if options.gfm do
-      rule_updates = [
+    rule_updates = if options.gfm do
+      rules = [
         escape:        ~r{^\\([\\`*\{\}\[\]()\#+\-.!_>~|])},
         url:           ~r{^(https?:\/\/[^\s<]+[^<.,:;\"\')\]\s])},
         strikethrough: ~r{^~~(?=\S)([\s\S]*?\S)~~},
@@ -290,20 +289,24 @@ defmodule Earmark.Inline do
           br:    ~r{^ *\n(?!\s*$)},
           text:  ~r{^[\s\S]+?(?=[\\<!\[_*`~]|https?://| *\n|$)}
         ]
-        rule_updates = Keyword.merge(rule_updates, break_updates)
+        Keyword.merge(rules, break_updates)
+      else
+        rules
       end
     else
       if options.pedantic do
-        rule_updates = [
+        [
           strong: ~r{^__(?=\S)([\s\S]*?\S)__(?!_)|^\*\*(?=\S)([\s\S]*?\S)\*\*(?!\*)},
           em:     ~r{^_(?=\S)([\s\S]*?\S)_(?!_)|^\*(?=\S)([\s\S]*?\S)\*(?!\*)}
         ]
+      else
+        []
       end
     end
-    if options.footnotes do
-      rule_updates = Keyword.merge(rule_updates, [footnote: ~r{^\[\^(#{@inside})\]}])
+    rule_updates = if options.footnotes do
+      Keyword.merge(rule_updates, [footnote: ~r{^\[\^(#{@inside})\]}])
     else
-      rule_updates = Keyword.merge(rule_updates, [footnote: ~r{\z\A}]) #noop
+      Keyword.merge(rule_updates, [footnote: ~r{\z\A}]) #noop
     end
     Keyword.merge(basic_rules, rule_updates)
     |> Enum.into(%{})


### PR DESCRIPTION
Elixir 1.2 deprecated conditional variable declaration with a warning
about "unsafe" variable. This updates those declarations to be a little
more verbose, but fit Elixir 1.2 and up.