### PR TITLE
Makes use of Map instead of Dict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ branches:
 elixir:
   - 1.0.5
   - 1.1
-otp_release: 
+  - 1.2
+otp_release:
   - 17.5
   - 18.0
   - 18.1
@@ -17,8 +18,8 @@ otp_release:
 matrix:
   include:
     - elixir: 1.2.0
-      otp_release: 18.0 
+      otp_release: 18.0
     - elixir: 1.2.1
-      otp_release: 18.1 
+      otp_release: 18.1
     - elixir: 1.2.3
-      otp_release: 18.1 
+      otp_release: 18.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ branches:
     - development
 
 elixir:
-  - 1.0.5
-  - 1.1
   - 1.2
 otp_release:
   - 17.5

--- a/lib/earmark/block.ex
+++ b/lib/earmark/block.ex
@@ -474,11 +474,11 @@ defmodule Earmark.Block do
   #####################################################
 
   defp links_from_blocks(blocks) do
-    visit(blocks, HashDict.new, &link_extractor/2)
+    visit(blocks, Map.new, &link_extractor/2)
   end
 
   defp link_extractor(item = %IdDef{id: id}, result) do
-    Dict.put(result, String.downcase(id), item)
+    Map.put(result, String.downcase(id), item)
   end
 
   defp link_extractor(_, result), do: result

--- a/lib/earmark/context.ex
+++ b/lib/earmark/context.ex
@@ -1,10 +1,7 @@
 defmodule Earmark.Options do
-
-  
-             # what we use to render
+             # What we use to render
   defstruct  renderer: Earmark.HtmlRenderer,
-
-             # inline style options  
+             # Inline style options
              gfm: true, breaks: false, pedantic: false,
              smartypants: true, sanitize: false,
              footnotes: false, footnote_offset: 1,
@@ -21,8 +18,7 @@ end
 
 defmodule Earmark.Context do
   defstruct options:  %Earmark.Options{},
-            links:    HashDict.new,
+            links:    Map.new,
             rules:    nil,
-            footnotes: HashDict.new
-
+            footnotes: Map.new
 end

--- a/lib/earmark/html_renderer.ex
+++ b/lib/earmark/html_renderer.ex
@@ -64,7 +64,7 @@ defmodule Earmark.HtmlRenderer do
 
   def render_block(%Block.BlockQuote{blocks: blocks, attrs: attrs}, context, mf) do
     body = render(blocks, context, mf)
-    html = "<blockquote>#{body}</blockquote>\n" 
+    html = "<blockquote>#{body}</blockquote>\n"
     add_attrs(html, attrs)
   end
 
@@ -203,7 +203,7 @@ defmodule Earmark.HtmlRenderer do
 
   def add_attrs(text, attrs, default) do
     default
-    |> Enum.into(HashDict.new)
+    |> Enum.into(Map.new)
     |> expand(attrs)
     |> attrs_to_string
     |> add_to(text)
@@ -215,27 +215,27 @@ defmodule Earmark.HtmlRenderer do
 
       match = Regex.run(~r{^\.(\S+)\s*}, attrs) ->
         [ leader, class ] = match
-          Dict.update(dict, "class", [ class ], &[ class | &1])
+          Map.update(dict, "class", [ class ], &[ class | &1])
           |> expand(behead(attrs, leader))
 
           match = Regex.run(~r{^\#(\S+)\s*}, attrs) ->
             [ leader, id ] = match
-              Dict.update(dict, "id", [ id ], &[ id | &1])
+              Map.update(dict, "id", [ id ], &[ id | &1])
               |> expand(behead(attrs, leader))
 
             match = Regex.run(~r{^(\S+)=\'([^\']*)'\s*}, attrs) -> #'
             [ leader, name, value ] = match
-              Dict.update(dict, name, [ value ], &[ value | &1])
+              Map.update(dict, name, [ value ], &[ value | &1])
               |> expand(behead(attrs, leader))
 
             match = Regex.run(~r{^(\S+)=\"([^\"]*)"\s*}, attrs) -> #"
             [ leader, name, value ] = match
-              Dict.update(dict, name, [ value ], &[ value | &1])
+              Map.update(dict, name, [ value ], &[ value | &1])
               |> expand(behead(attrs, leader))
 
               match = Regex.run(~r{^(\S+)=(\S+)\s*}, attrs) ->
                 [ leader, name, value ] = match
-                  Dict.update(dict, name, [ value ], &[ value | &1])
+                  Map.update(dict, name, [ value ], &[ value | &1])
                   |> expand(behead(attrs, leader))
 
                   :otherwise ->
@@ -245,8 +245,8 @@ defmodule Earmark.HtmlRenderer do
 
   def attrs_to_string(attrs) do
     (for { name, value } <- attrs, do: ~s/#{name}="#{Enum.join(value, " ")}"/)
-                                                  |> Enum.join(" ")                                      
-  end                            
+                                                  |> Enum.join(" ")
+  end
 
   def add_to(attrs, text) do
     String.replace(text, ~r{\s?/?>}, " #{attrs}\\0", global: false)

--- a/lib/earmark/inline.ex
+++ b/lib/earmark/inline.ex
@@ -202,14 +202,15 @@ defmodule Earmark.Inline do
 
   defp reference_link(context, match, alt_text, id) do
     id = id |> replace(~r{\s+}, " ") |> String.downcase
-    case Dict.fetch(context.links, id) do
+
+    case Map.fetch(context.links, id) do
       {:ok, link } -> output_image_or_link(context, match, alt_text, link.url, link.title)
       _            -> match
     end
   end
 
   defp footnote_link(context, match, id) do
-    case Dict.fetch(context.footnotes, id) do
+    case Map.fetch(context.footnotes, id) do
       {:ok, footnote} -> number = footnote.number
                          output_footnote_link(context, "fn:#{number}", "fnref:#{number}", number)
       _               -> match
@@ -260,7 +261,7 @@ defmodule Earmark.Inline do
     autolink: ~r{^<([^ >]+(@|:\/)[^ >]+)>},
     url:      ~r{\z\A},  # noop
     tag:      ~r{
-      ^<!--[\s\S]*?--> | 
+      ^<!--[\s\S]*?--> |
       ^<\/?\w+(?: "[^"<]*" | # < inside an attribute is illegal, luckily
                   '[^'<]*' |
                    [^'"<>])*?>}x,

--- a/lib/earmark/parser.ex
+++ b/lib/earmark/parser.ex
@@ -10,7 +10,7 @@ defmodule Earmark.Parser do
 
   def parse(text_lines, options = %Earmark.Options{}, recursive \\ false) do
     # add blank lines before and after
-    [ "" | text_lines ++ [""] ] 
+    [ "" | text_lines ++ [""] ]
     |> Earmark.pmap(fn (line) -> Line.type_of(line, options, recursive) end)
     |> Block.parse
   end
@@ -25,7 +25,7 @@ defmodule Earmark.Parser do
                 |> List.flatten
                 |> get_footnote_numbers(footnotes, options)
     blocks = create_footnote_blocks(blocks, footnotes)
-    footnotes = map_func.(footnotes, &({&1.id, &1})) |> Enum.into(HashDict.new)
+    footnotes = map_func.(footnotes, &({&1.id, &1})) |> Enum.into(Map.new)
     { blocks, footnotes }
   end
 
@@ -57,5 +57,5 @@ defmodule Earmark.Parser do
     footnote_block = %Block.FnList{blocks: Enum.sort_by(footnotes, &(&1.number))}
     Enum.concat(blocks, [footnote_block])
   end
-  
+
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Earmark.Mixfile do
     [
       app:          :earmark,
       version:      "0.2.2",
-      elixir:       ">= 1.0.0",
+      elixir:       "~> 1.2",
       elixirc_paths: elixirc_paths(Mix.env),
       escript:       escript_config,
       deps:          deps,

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -11,7 +11,7 @@ defmodule BlockTest do
 
   test "Setext Heading" do
     result = Block.lines_to_blocks([
-                %Line.Blank{}, 
+                %Line.Blank{},
                 %Line.Text{content: "Heading"},
                 %Line.SetextUnderlineHeading{level: 1},
                 %Line.Blank{}
@@ -128,12 +128,12 @@ defmodule BlockTest do
                   %Line.HtmlCloseTag{tag: "table", line: "</table>"},
              ])
 
-    expected = [%Block.Html{tag: "table", html: 
-                 ["<table class='c'>", 
-                  "line 1", 
-                  "<pre>", 
+    expected = [%Block.Html{tag: "table", html:
+                 ["<table class='c'>",
+                  "line 1",
+                  "<pre>",
                   "line 2",
-                  "</pre>", 
+                  "</pre>",
                   "line 3",
                   "</table>"]}]
 
@@ -151,12 +151,12 @@ defmodule BlockTest do
                   %Line.HtmlCloseTag{tag: "table", line: "</table>"},
              ])
 
-    expected = [%Block.Html{tag: "table", html: 
-                 ["<table class='c'>", 
-                  "line 1", 
-                  "<table>", 
+    expected = [%Block.Html{tag: "table", html:
+                 ["<table class='c'>",
+                  "line 1",
+                  "<table>",
                   "line 2",
-                  "</table>", 
+                  "</table>",
                   "line 3",
                   "</table>"]}]
 
@@ -213,7 +213,7 @@ defmodule BlockTest do
 
     assert result == [
         %Block.IdDef{id: "id1", title: nil, url: "url1"},
-        %Block.Para{lines: [ "  not title1" ]} 
+        %Block.Para{lines: [ "  not title1" ]}
     ]
   end
 
@@ -230,7 +230,7 @@ defmodule BlockTest do
 
     assert result == [
         %Block.Para{lines: [ "line" ], attrs: ".a1 .a2"},
-        %Block.Para{lines: [ "another" ], attrs: nil} 
+        %Block.Para{lines: [ "another" ], attrs: nil}
     ]
   end
 
@@ -245,7 +245,7 @@ defmodule BlockTest do
 
     defn = %Block.IdDef{id: "id1", title: "title1", url: "url1"}
     assert blocks == [defn]
-    assert refs == ([{ "id1", defn}] |> Enum.into(HashDict.new))
+    assert refs == ([{ "id1", defn}] |> Enum.into(Map.new))
   end
 
   test "ID definition nested in list" do
@@ -262,9 +262,8 @@ defmodule BlockTest do
                %Block.Para{lines: ["line 1"]},
                defn
     ]}]}]
-    
-    assert blocks == expected
-    assert refs == ([{ "id1", defn}] |> Enum.into(HashDict.new))
-  end
 
+    assert blocks == expected
+    assert refs == ([{ "id1", defn}] |> Enum.into(Map.new))
+  end
 end

--- a/test/footnote_test.exs
+++ b/test/footnote_test.exs
@@ -8,7 +8,7 @@ defmodule FootnoteTest do
 
   def test_footnotes do
     [ {"fn-a", %Block.FnDef{id: "fn-a", number: 1}} ]
-    |> Enum.into(HashDict.new)
+    |> Enum.into(Map.new)
   end
 
   def options do
@@ -72,11 +72,11 @@ defmodule FootnoteTest do
              ]
 
     {result, _} = Parser.parse(lines)
-    expected = [%Block.Para{attrs: nil, lines: ["This is a footnote[^fn-1]"]}, 
+    expected = [%Block.Para{attrs: nil, lines: ["This is a footnote[^fn-1]"]},
 		%Block.Para{attrs: nil, lines: ["[^fn-1]: line 1", "line 2"]},
-            	%Block.Code{attrs: nil, language: nil, lines: ["Para 2 line 1", "Para 2 line 2", "", 
+            	%Block.Code{attrs: nil, language: nil, lines: ["Para 2 line 1", "Para 2 line 2", "",
 								       "* List Item 1", "  List Item 1 Cont", "* List Item 2"]
-		}]    
+		}]
     assert result == expected
 
     html = Earmark.to_html(lines, put_in(%Earmark.Options{}.footnotes, true))
@@ -116,7 +116,7 @@ defmodule FootnoteTest do
                      %Block.FnDef{id: "ref-2", number: 4, blocks: [%Block.Para{lines: ["ref 2"]}]}]
     expected_blocks = [para, %Block.FnList{blocks: output_fnotes}]
     assert blocks == expected_blocks
-    expected_fnotes = Enum.map(output_fnotes, &({&1.id, &1})) |> Enum.into(HashDict.new)
+    expected_fnotes = Enum.map(output_fnotes, &({&1.id, &1})) |> Enum.into(Map.new)
     assert footnotes == expected_fnotes
   end
 
@@ -129,7 +129,7 @@ defmodule FootnoteTest do
                       %Earmark.Block.Para{lines: ["para"]},
                       %Earmark.Block.FnList{blocks: [fn_def]}
                      ]
-    expect = HashDict.new |> HashDict.put("ref-id", fn_def)
+    expect = Map.new |> Map.put("ref-id", fn_def)
     assert footnotes == expect
   end
 

--- a/test/html_renderer/attribute_test.exs
+++ b/test/html_renderer/attribute_test.exs
@@ -5,7 +5,7 @@ defmodule HtmlRenderer.AttributeTest do
 
   # This is just for the internals...
 
-  def h(enum), do: Enum.into(enum, HashDict.new)
+  def h(enum), do: Enum.into(enum, Map.new)
 
   def newh, do: h([])
 
@@ -66,29 +66,32 @@ defmodule HtmlRenderer.AttributeTest do
   end
 
   test "multiple attributes added" do
-    assert add_attrs("<p>xxx</p>", "#one .two name=value") == 
-      "<p name=\"value\" id=\"one\" class=\"two\">xxx</p>"
+    assert add_attrs("<p>xxx</p>", "#one .two name=value") ==
+      "<p class=\"two\" id=\"one\" name=\"value\">xxx</p>"
   end
 
   test "multiple attributes added to empty tag" do
-    assert add_attrs("<br/>", "#one .two name=value") == 
-      ~s[<br name="value" id="one" class="two"/>]
+    assert add_attrs("<br/>", "#one .two name=value") ==
+      ~s[<br class="two" id="one" name="value"/>]
   end
+
   test "merges additional attributes" do
     assert add_attrs("<p>xxx</p>", ".one", [{"class", ["two"]}]) ==
       "<p class=\"one two\">xxx</p>"
   end
+
   test "merges additional attributes in empty tag" do
     assert add_attrs("<hr />", ".one", [{"class", ["two"]}]) ==
       "<hr class=\"one two\" />"
   end
+
   test "merges additional different attributes" do
     assert add_attrs("<p>xxx</p>", ".one", [{"id", ["two"]}]) ==
-      "<p id=\"two\" class=\"one\">xxx</p>"
-  end
-  test "merges additional different attributes in empty tag" do
-    assert add_attrs("<hr />", ".one", [{"id", ["two"]}]) ==
-      "<hr id=\"two\" class=\"one\" />"
+      "<p class=\"one\" id=\"two\">xxx</p>"
   end
 
+  test "merges additional different attributes in empty tag" do
+    assert add_attrs("<hr />", ".one", [{"id", ["two"]}]) ==
+      "<hr class=\"one\" id=\"two\" />"
+  end
 end

--- a/test/inline_test.exs
+++ b/test/inline_test.exs
@@ -60,7 +60,7 @@ defmodule InlineTest do
     result = convert_pedantic("hello \\*world\\*")
     assert result == "hello *world*"
   end
-  
+
   test "tilde mean strikethrough" do
     result = convert_gfm("this ~~not this~~")
     assert result == "this <del>not this</del>"
@@ -99,17 +99,17 @@ defmodule InlineTest do
 
   test "basic inline link" do
     result = convert_pedantic(~s{a [an example](http://example.com/ "Title") link})
-    assert result == ~s[a <a href="http://example.com/" title="Title">an example</a> link]  
+    assert result == ~s[a <a href="http://example.com/" title="Title">an example</a> link]
   end
 
   test "basic inline link with title in single quotes" do
     result = convert_pedantic(~s{a [an example](http://example.com/ 'Title') link})
-    assert result == ~s[a <a href="http://example.com/" title="Title">an example</a> link]  
+    assert result == ~s[a <a href="http://example.com/" title="Title">an example</a> link]
   end
 
   test "link with no title" do
     result = convert_pedantic(~s{a [an example](http://example.com/) link})
-    assert result == ~s[a <a href="http://example.com/">an example</a> link]  
+    assert result == ~s[a <a href="http://example.com/">an example</a> link]
   end
 
   ###################
@@ -125,12 +125,12 @@ defmodule InlineTest do
     result = convert_pedantic(~s{a [my link][ID1] link})
     assert result == ~s[a <a href=\"url%201\" title=\"title 1\">my link</a> link]
   end
-                               
+
   test "basic reference link with no title" do
     result = convert_pedantic(~s{a [my link][id2] link})
     assert result == ~s[a <a href="url%202">my link</a> link]
   end
-                               
+
   test "basic reference link with a space inside" do
     result = convert_pedantic(~s{a [mylink]  [id1] link})
     assert result == ~s[a <a href=\"url%201\" title=\"title 1\">mylink</a> link]
@@ -148,17 +148,18 @@ defmodule InlineTest do
 
   test "basic reference image link" do
     result = convert_pedantic(~s{a ![my image][img1] link})
-    assert result == 
+
+    assert result ==
       ~s[a <img src="img%201" alt="my image" title="image 1"/> link]
   end
-                               
+
   test "basic reference image link with no title" do
     result = convert_pedantic(~s{a ![my image][img2] link})
-    assert result == 
+    assert result ==
       ~s[a <img src="img%202" alt="my image"/> link]
   end
-                               
-                               
+
+
   ###############
   # Inline HTML #
   ###############
@@ -166,5 +167,5 @@ defmodule InlineTest do
   test "inline HTML" do
     result = convert_pedantic(~s[a <span class="red">a&b</span> color])
     assert result == ~s[a <span class="red">a&amp;b</span> color]
-  end                               
+  end
 end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -1,5 +1,5 @@
-defmodule Support.Helpers do 
-  
+defmodule Support.Helpers do
+
   alias Earmark.Inline
   alias Earmark.Block.IdDef
 
@@ -12,14 +12,14 @@ defmodule Support.Helpers do
   end
 
   def test_links do
-    [ 
+    [
      {"id1", %IdDef{url: "url 1", title: "title 1"}},
      {"id2", %IdDef{url: "url 2"}},
 
      {"img1", %IdDef{url: "img 1", title: "image 1"}},
      {"img2", %IdDef{url: "img 2"}},
     ]
-    |> Enum.into(HashDict.new)
+    |> Enum.into(Map.new)
   end
 
   def pedantic_context do
@@ -36,7 +36,7 @@ defmodule Support.Helpers do
   def convert_pedantic(string) do
     Inline.convert(string, pedantic_context)
   end
-    
+
   def convert_gfm(string) do
     Inline.convert(string, gfm_context)
   end


### PR DESCRIPTION
Removes HashDict and Dict data types in favor of Map.
http://elixir-lang.org/docs/stable/elixir/HashDict.html