### PR TITLE
Upgrade poison dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Earmark.Mixfile do
   end
 
   defp deps do
-    [{:poison, "~> 1.5", only: [:dev, :test]},
+    [{:poison, "~> 2.1", only: [:dev, :test]},
      {:kwfuns, "~> 0.0", only: :test}]
   end
 

--- a/test/acceptance/acceptance_test_creator_test.exs
+++ b/test/acceptance/acceptance_test_creator_test.exs
@@ -9,7 +9,7 @@ defmodule AcceptanceTestCreatorTest do
   |> File.stream!( [], :line )
   |> Enum.reject( &(String.match?(&1, ~r{^\s*#})) )
   |> Enum.join( "\n" )
-  |> Poison.decode( as: [AcceptanceTestStruct] )
+  |> Poison.decode( as: [%AcceptanceTestStruct{}] )
 
 
   for acceptance_test <- test_case_data do


### PR DESCRIPTION
This will prevent a warning coming from old poison version duruing installation.