### PR TITLE
Fix a bunch of warnings

### DIFF
--- a/lib/earmark/inline.ex
+++ b/lib/earmark/inline.ex
@@ -61,7 +61,7 @@ defmodule Earmark.Inline do
                                   end
                                   out = output_image_or_link(context, match, text, href, title)
                                   result = convert_each(behead(src, match), context, [ result | out ])
-                                  result 
+                                  result
 
 
                                   # reflink
@@ -308,7 +308,7 @@ defmodule Earmark.Inline do
     end
     footnote = if options.footnotes, do: ~r{^\[\^(#{@inside})\]}, else: ~r{\z\A}
     rule_updates = Keyword.merge(rule_updates, [footnote: footnote])
-    Keyword.merge(basic_rules, rule_updates)
+    Keyword.merge(basic_rules(), rule_updates)
     |> Enum.into(%{})
   end
   end

--- a/lib/earmark/types.ex
+++ b/lib/earmark/types.ex
@@ -1,6 +1,6 @@
 defmodule Earmark.Types do
 
-  defmacro __using__(options \\ []) do
+  defmacro __using__(_options \\ []) do
     quote do
       @type numbered_line :: %{line: String.t, lnb: number}
       @type maybe(t) :: t | :nil

--- a/mix.exs
+++ b/mix.exs
@@ -9,10 +9,10 @@ defmodule Earmark.Mixfile do
       version:      "0.2.2",
       elixir:       "~> 1.2",
       elixirc_paths: elixirc_paths(Mix.env),
-      escript:       escript_config,
-      deps:          deps,
-      description:   description,
-      package:       package,
+      escript:       escript_config(),
+      deps:          deps(),
+      description:   description(),
+      package:       package(),
     ]
   end
 

--- a/test/block_test.exs
+++ b/test/block_test.exs
@@ -16,13 +16,13 @@ defmodule BlockTest do
                 %Line.Text{content: "Heading"},
                 %Line.SetextUnderlineHeading{level: 1}
                 # %Line.Blank{}
-             ], filename)
+             ], filename())
 
     assert result == [ %Block.Heading{content: "Heading", level: 1} ]
   end
 
   test "Regular heading" do
-    result = Block.lines_to_blocks([ %Line.Heading{content: "Heading", level: 2} ], filename)
+    result = Block.lines_to_blocks([ %Line.Heading{content: "Heading", level: 2} ], filename())
     assert result == [ %Block.Heading{content: "Heading", level: 2} ]
   end
 
@@ -31,7 +31,7 @@ defmodule BlockTest do
   ##########
 
   test "Ruler" do
-    result = Block.lines_to_blocks([ %Line.Ruler{type: "-"} ], filename)
+    result = Block.lines_to_blocks([ %Line.Ruler{type: "-"} ], filename())
     assert result == [ %Block.Ruler{type: "-"} ]
   end
 
@@ -43,7 +43,7 @@ defmodule BlockTest do
     result = Block.lines_to_blocks([
                %Line.BlockQuote{content: "line 1"},
                %Line.BlockQuote{content: "line 2"}
-             ], filename)
+             ], filename())
 
     expected = [%Block.BlockQuote{blocks: [%Block.Para{lines: ["line 1", "line 2"]}]}]
     assert result == expected
@@ -53,7 +53,7 @@ defmodule BlockTest do
     result = Block.lines_to_blocks([
                %Line.BlockQuote{content: "line 1"},
                %Line.Text{content: "line 2"}
-             ], filename)
+             ], filename())
 
     expected = [%Block.BlockQuote{blocks: [%Block.Para{lines: ["line 1", "line 2"]}]}]
     assert result == expected
@@ -71,7 +71,7 @@ defmodule BlockTest do
                   %Line.Blank{},
                   %Line.Indent{level: 1, content: " line 3"},
                   %Line.Indent{level: 1, content: "line 4"}
-             ], filename)
+             ], filename())
 
     expected = [%Block.Code{language: nil,
                             lines: ["line 1", " line 2", "", " line 3", "line 4"]}]
@@ -84,7 +84,7 @@ defmodule BlockTest do
                   %Line.Indent{level: 1, content: "  line 2"},
                   %Line.Indent{level: 2, content: "line 3"},
                   %Line.Indent{level: 2, content: "  line 4"}
-             ], filename)
+             ], filename())
 
     expected = [%Block.Code{language: nil,
                             lines: ["line 1", "  line 2", "    line 3", "      line 4"]}]
@@ -98,7 +98,7 @@ defmodule BlockTest do
                   %Line.Blank{line: ""},
                   %Line.Indent{level: 1, content: "line 2", line: "    line 2"},
                   %Line.Fence{delimiter: "~~~"},
-             ], filename)
+             ], filename())
     expected = [%Block.Code{language: "elixir", lines: ["line 1", "", "    line 2"]}]
     assert result == expected
   end
@@ -109,7 +109,7 @@ defmodule BlockTest do
                   %Line.Fence{delimiter: "```", language: "elixir", line: "``` elixir"},
                   %Line.Text{content: "line 1", line: "line 1"},
                   %Line.Fence{delimiter: "~~~"},
-             ], filename)
+             ], filename())
     expected = [%Block.Code{language: "elixir", lines: ["``` elixir", "line 1"]}]
     assert result == expected
   end
@@ -127,7 +127,7 @@ defmodule BlockTest do
                   %Line.HtmlCloseTag{tag: "pre", line: "</pre>"},
                   %Line.Text{line: "line 3"},
                   %Line.HtmlCloseTag{tag: "table", line: "</table>"},
-             ], filename)
+             ], filename())
 
     expected = [%Block.Html{tag: "table", html:
                  ["<table class='c'>",
@@ -150,7 +150,7 @@ defmodule BlockTest do
                   %Line.HtmlCloseTag{tag: "table", line: "</table>"},
                   %Line.Text{line: "line 3"},
                   %Line.HtmlCloseTag{tag: "table", line: "</table>"},
-             ], filename)
+             ], filename())
 
     expected = [%Block.Html{tag: "table", html:
                  ["<table class='c'>",
@@ -168,7 +168,7 @@ defmodule BlockTest do
   test "HTML comment on one line" do
     result = Block.lines_to_blocks([
                   %Line.HtmlComment{line: "<!-- xx -->", complete: true}
-             ], filename)
+             ], filename())
     expected = [ %Block.HtmlOther{html: [ "<!-- xx -->" ]}]
 
     assert result == expected
@@ -179,7 +179,7 @@ defmodule BlockTest do
                   %Line.HtmlComment{line: "<!-- ", complete: false},
                   %Line.Indent{level: 2, line: "xxx"},
                   %Line.Text{line: "-->"}
-             ], filename)
+             ], filename())
     expected = [ %Block.HtmlOther{html: ["<!-- ", "xxx", "-->"]}]
 
     assert result == expected
@@ -192,7 +192,7 @@ defmodule BlockTest do
   test "Basic ID definition" do
     result = Block.lines_to_blocks([
                   %Line.IdDef{id: "id1", url: "url1", title: "title1"}
-             ], filename)
+             ], filename())
 
     assert result == [%Block.IdDef{id: "id1", title: "title1", url: "url1"}]
   end
@@ -201,7 +201,7 @@ defmodule BlockTest do
     result = Block.lines_to_blocks([
                   %Line.IdDef{id: "id1", url: "url1"},
                   %Line.Text{content: "  (title1)"}
-             ], filename)
+             ], filename())
 
     assert result == [%Block.IdDef{id: "id1", title: "title1", url: "url1"}]
   end
@@ -210,7 +210,7 @@ defmodule BlockTest do
     result = Block.lines_to_blocks([
                   %Line.IdDef{id: "id1", url: "url1"},
                   %Line.Text{content: "  not title1", line: "  not title1"}
-             ], filename)
+             ], filename())
 
     assert result == [
         %Block.IdDef{id: "id1", title: nil, url: "url1"},
@@ -227,7 +227,7 @@ defmodule BlockTest do
                   %Line.Text{line: "line", content: "line"},
                   %Line.Ial{attrs: ".a1 .a2"},
                   %Line.Text{content: "another", line: "another"}
-             ], filename)
+             ], filename())
 
     assert result == [
         %Block.Para{lines: [ "line" ], attrs: ".a1 .a2"},
@@ -242,7 +242,7 @@ defmodule BlockTest do
   test "Accumulate basic ID definition" do
     {blocks, refs } = Block.parse([
                   %Line.IdDef{id: "id1", url: "url1", title: "title1"}
-             ], filename)
+             ], filename())
 
     defn = %Block.IdDef{id: "id1", title: "title1", url: "url1"}
     assert blocks == [defn]
@@ -254,7 +254,7 @@ defmodule BlockTest do
                %Line.ListItem{type: :ul, bullet: "*", content: "line 1"},
                %Line.Blank{},
                %Line.Indent{level: 1, content: "[id1]: url1  (title1)"},
-             ], filename)
+             ], filename())
 
     defn = %Block.IdDef{id: "id1", title: "title1", url: "url1"}
 

--- a/test/footnote_test.exs
+++ b/test/footnote_test.exs
@@ -16,13 +16,13 @@ defmodule FootnoteTest do
   end
 
   def context do
-    ctx = put_in(%Earmark.Context{}.options, options)
-    ctx = put_in(ctx.footnotes, test_footnotes)
+    ctx = put_in(%Earmark.Context{}.options, options())
+    ctx = put_in(ctx.footnotes, test_footnotes())
     Inline.update_context(ctx)
   end
 
   def convert(string) do
-    Inline.convert(string, context)
+    Inline.convert(string, context())
   end
 
   test "handles FnDef blocks without Footnotes enabled" do
@@ -33,7 +33,7 @@ defmodule FootnoteTest do
 
   test "handles text without footntoes when Footnotes enabled" do
     lines = ["This is some regular text"]
-    Earmark.to_html(lines, options)
+    Earmark.to_html(lines, options())
   end
 
   test "basic footnote link" do
@@ -42,7 +42,7 @@ defmodule FootnoteTest do
   end
 
   test "pulls one-line footnote bodies" do
-    result = Block.lines_to_blocks([ %Line.FnDef{id: "some-fn", content: "This is a footnote."} ], filename)
+    result = Block.lines_to_blocks([ %Line.FnDef{id: "some-fn", content: "This is a footnote."} ], filename())
     assert result == [%Block.FnDef{id: "some-fn", blocks: [%Block.Para{lines: ["This is a footnote."]}]}]
   end
 
@@ -50,7 +50,7 @@ defmodule FootnoteTest do
     result = Block.lines_to_blocks([
                 %Line.FnDef{id: "some-fn", content: "This is a multi-line"},
                 %Line.Text{content: "footnote example.", line: "footnote example."}
-             ], filename)
+             ], filename())
     expected = [%Block.FnDef{id: "some-fn", blocks: [
                   %Block.Para{lines: ["This is a multi-line", "footnote example."]}
                 ]}]
@@ -110,7 +110,7 @@ defmodule FootnoteTest do
     text = [para,
             %Block.FnDef{id: "ref-2", blocks: [%Block.Para{lines: ["ref 2"]}]},
             %Block.FnDef{id: "ref-1", blocks: [%Block.Para{lines: ["ref 1"]}]}]
-    opts = put_in(options.footnote_offset, 3)
+    opts = put_in(options().footnote_offset, 3)
     { blocks, footnotes } = Parser.handle_footnotes(text, opts, &Enum.map/2)
     output_fnotes = [%Block.FnDef{id: "ref-1", number: 3, blocks: [%Block.Para{lines: ["ref 1"]}]},
                      %Block.FnDef{id: "ref-2", number: 4, blocks: [%Block.Para{lines: ["ref 2"]}]}]
@@ -121,8 +121,8 @@ defmodule FootnoteTest do
   end
 
   test "parses footnote content" do
-    {blocks, _} = Parser.parse(["para[^ref-id]", "", "[^ref-id]: line 1", "line 2", "line 3", "", "para"], options)
-    {blocks, footnotes} = Parser.handle_footnotes(blocks, options, &Enum.map/2)
+    {blocks, _} = Parser.parse(["para[^ref-id]", "", "[^ref-id]: line 1", "line 2", "line 3", "", "para"], options())
+    {blocks, footnotes} = Parser.handle_footnotes(blocks, options(), &Enum.map/2)
     fn_content = [%Earmark.Block.Para{lines: ["line 1", "line 2", "line 3"]}]
     fn_def = %Earmark.Block.FnDef{id: "ref-id", number: 1, blocks: fn_content }
     assert blocks == [%Earmark.Block.Para{lines: ["para[^ref-id]"]},
@@ -157,7 +157,7 @@ defmodule FootnoteTest do
     assert "#{result}\n" == expected
   end
 
-  defp filename do 
+  defp filename do
     "file name"
   end
 end

--- a/test/headings_test.exs
+++ b/test/headings_test.exs
@@ -10,13 +10,13 @@ defmodule HeadingsTest do
   defp render [level: level, content: content] do
     Renderer.render_block(
       %Heading{attrs: nil, level: level, content: content},
-      inline_context,
+      inline_context(),
       false
     )
   end
 
   defp inline_context do
-   Earmark.Inline.update_context( context )
+   Earmark.Inline.update_context( context() )
   end
 
 

--- a/test/lists_test.exs
+++ b/test/lists_test.exs
@@ -7,7 +7,7 @@ defmodule ListTest do
   test "Basic UL" do
     result = Block.lines_to_blocks([
                %Line.ListItem{type: :ul, bullet: "*", content: "line 1"}
-             ], filename)
+             ], filename())
     expected = [ %Block.List{ type: :ul, blocks: [
          %Block.ListItem{type: :ul, blocks: [%Block.Para{lines: ["line 1"]}], spaced: false}
     ]}]
@@ -18,7 +18,7 @@ defmodule ListTest do
     result = Block.lines_to_blocks([
                %Line.ListItem{type: :ul, bullet: "*", content: "line 1"},
                %Line.Text{content: "line 2"}
-             ], filename)
+             ], filename())
     expected = [ %Block.List{ type: :ul, blocks: [
          %Block.ListItem{type: :ul, blocks: [
                 %Block.Para{lines: ["line 1", "line 2"]}], spaced: false}
@@ -32,7 +32,7 @@ defmodule ListTest do
                %Line.Blank{},
                %Line.Indent{content: "line 2", level: 1},
                %Line.Blank{}
-             ], filename)
+             ], filename())
     expected = [ %Block.List{ type: :ul, blocks: [
          %Block.ListItem{blocks: [%Block.Para{lines: ["line 1"]},
                                 %Block.Para{lines: ["line 2"]}],
@@ -47,7 +47,7 @@ defmodule ListTest do
                %Line.Blank{},
                %Line.Text{content: "  line 2", line: "  line 2"},
                %Line.Blank{}
-             ], filename)
+             ], filename())
     expected = [ %Block.List{ type: :ul, blocks: [
          %Block.ListItem{blocks: [%Block.Para{lines: ["line 1"]},
                                 %Block.Para{lines: ["  line 2"]}],
@@ -61,7 +61,7 @@ defmodule ListTest do
                %Line.ListItem{bullet: "*", content: "line 1"},
                %Line.Text{content: "line 2"},
                %Line.Blank{}
-             ], filename)
+             ], filename())
     expected = [ %Block.List{ type: :ul, blocks: [
          %Block.ListItem{type: :ul, blocks: [
                  %Block.Para{lines: ["line 1", "line 2"]}], spaced: false}
@@ -73,7 +73,7 @@ defmodule ListTest do
     result = Block.lines_to_blocks([
                %Line.ListItem{type: :ul, bullet: "*", content: "line 1"},
                %Line.ListItem{type: :ul, bullet: "*", content: "line 2"},
-             ], filename)
+             ], filename())
     expected = [ %Block.List{ type: :ul, blocks: [
        %Block.ListItem{type: :ul, blocks: [%Block.Para{lines: ["line 1"]}], spaced: false},
        %Block.ListItem{type: :ul, blocks: [%Block.Para{lines: ["line 2"]}], spaced: false},
@@ -86,7 +86,7 @@ defmodule ListTest do
                %Line.ListItem{type: :ul, bullet: "*", content: "line 1"},
                %Line.Blank{},
                %Line.ListItem{type: :ul, bullet: "*", content: "line 2"},
-             ], filename)
+             ], filename())
     expected = [ %Block.List{ type: :ul, blocks: [
        %Block.ListItem{type: :ul, blocks: [%Block.Para{lines: ["line 1"]}], spaced: true},
        %Block.ListItem{type: :ul, blocks: [%Block.Para{lines: ["line 2"]}], spaced: false},
@@ -100,8 +100,8 @@ defmodule ListTest do
                %Line.ListItem{type: :ul, bullet: "*", content: "line 2"},
                %Line.Blank{},
                %Line.Text{content: "para", line: "para"}
-             ], filename)
-    expected = [ 
+             ], filename())
+    expected = [
        %Block.List{ type: :ul, blocks: [
          %Block.ListItem{type: :ul, blocks: [%Block.Para{lines: ["line 1"]}], spaced: false},
          %Block.ListItem{type: :ul, blocks: [%Block.Para{lines: ["line 2"]}], spaced: false},
@@ -119,7 +119,7 @@ defmodule ListTest do
                %Line.Indent{level: 3, content: "code 2", lnb: 1},
                %Line.Blank{ lnb: 1},
                %Line.Indent{level: 1, content: "line 2", lnb: 1},
-             ], filename)
+             ], filename())
 
     expected = [ %Block.List{ type: :ul, blocks: [
        %Block.ListItem{type: :ul, blocks: [
@@ -127,18 +127,18 @@ defmodule ListTest do
                %Block.Code{language: nil, lines: ["code 1", "    code 2"]},
                %Block.Para{lines: ["line 2"]}], spaced: false}
     ]}]
-    
+
     assert result == expected
   end
 
   # OLs are handled by the same code as ULs, so to save time, we really just
-  # need a single smoke test. If this changes in future, we'll need to 
+  # need a single smoke test. If this changes in future, we'll need to
   # relook at this
 
   test "Basic OL" do
     result = Block.lines_to_blocks([
                %Line.ListItem{type: :ol, bullet: "1.", content: "line 1"}
-             ], filename)
+             ], filename())
     expected = [ %Block.List{ type: :ol, blocks: [
          %Block.ListItem{type: :ol, blocks: [%Block.Para{lines: ["line 1"]}], spaced: false}
     ]}]
@@ -146,7 +146,7 @@ defmodule ListTest do
   end
 
 
-  
+
   test "Simple list render" do
     result = Earmark.to_html(["* one", "* two"])
     expected = """
@@ -172,7 +172,7 @@ defmodule ListTest do
 
   test "Initial indentation of * taken into account when looking at body" do
     result = Earmark.to_html([
-    "   * one", 
+    "   * one",
     "     one.one",
     "   * two"
     ])
@@ -186,7 +186,7 @@ defmodule ListTest do
     assert result == expected
   end
 
-  defp filename do 
+  defp filename do
     "some file"
   end
 end

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -23,22 +23,22 @@ defmodule Support.Helpers do
   end
 
   def pedantic_context do
-    ctx = put_in(context.options.gfm, false)
+    ctx = put_in(context().options.gfm, false)
     ctx = put_in(ctx.options.pedantic, true)
-    ctx = put_in(ctx.links, test_links)
+    ctx = put_in(ctx.links, test_links())
     Inline.update_context(ctx)
   end
 
   def gfm_context do
-    Inline.update_context(context)
+    Inline.update_context(context())
   end
 
   def convert_pedantic(string) do
-    Inline.convert(string, pedantic_context)
+    Inline.convert(string, pedantic_context())
   end
 
   def convert_gfm(string) do
-    Inline.convert(string, gfm_context)
+    Inline.convert(string, gfm_context())
   end
 
 end

--- a/test/table_test.exs
+++ b/test/table_test.exs
@@ -6,22 +6,22 @@ defmodule TableTest do
 
   test "test one table line is just a paragraph" do
     result = Block.lines_to_blocks([
-                %Line.TableLine{columns: ~w{a b c}, line: "a | b | c"}, 
+                %Line.TableLine{columns: ~w{a b c}, line: "a | b | c"},
                 %Line.Blank{}
-             ], filename)
+             ], filename())
 
     assert result == [ %Block.Para{lines: ["a | b | c"]} ]
   end
 
   test "test two table lines make a table" do
     result = Block.lines_to_blocks([
-                %Line.TableLine{columns: ~w{a b c}, line: "a | b | c"}, 
-                %Line.TableLine{columns: ~w{d e f}, line: "d | e | f"}, 
+                %Line.TableLine{columns: ~w{a b c}, line: "a | b | c"},
+                %Line.TableLine{columns: ~w{d e f}, line: "d | e | f"},
                 %Line.Blank{}
-             ], filename)
+             ], filename())
 
     expected = %Block.Table{
-      rows:       [ ~w{a b c}, ~w{d e f} ], 
+      rows:       [ ~w{a b c}, ~w{d e f} ],
       alignments: [ :left, :left, :left ],
       header:     nil}
 
@@ -30,15 +30,15 @@ defmodule TableTest do
 
   test "test heading" do
     result = Block.lines_to_blocks([
-                %Line.TableLine{columns: ~w{a b c},        line: "a | b | c"}, 
-                %Line.TableLine{columns: ~w{ --- --- ---}, line: "--|---|--"}, 
-                %Line.TableLine{columns: ~w{d e f},        line: "d | e | f"}, 
+                %Line.TableLine{columns: ~w{a b c},        line: "a | b | c"},
+                %Line.TableLine{columns: ~w{ --- --- ---}, line: "--|---|--"},
+                %Line.TableLine{columns: ~w{d e f},        line: "d | e | f"},
                 %Line.Blank{}
-             ], filename)
+             ], filename())
 
     expected = %Block.Table{
-      header:     ~w{a b c}, 
-      rows:       [ ~w{d e f} ], 
+      header:     ~w{a b c},
+      rows:       [ ~w{d e f} ],
       alignments: [ :left, :left, :left ]}
 
     assert result == [ expected ]
@@ -46,22 +46,22 @@ defmodule TableTest do
 
   test "test alignment" do
     result = Block.lines_to_blocks([
-                %Line.TableLine{columns: ~w{a b c},        line: "a | b | c"}, 
-                %Line.TableLine{columns: ~w{ --: :--: :---}, line: "--|---|--"}, 
-                %Line.TableLine{columns: ~w{d e f},        line: "d | e | f"}, 
+                %Line.TableLine{columns: ~w{a b c},        line: "a | b | c"},
+                %Line.TableLine{columns: ~w{ --: :--: :---}, line: "--|---|--"},
+                %Line.TableLine{columns: ~w{d e f},        line: "d | e | f"},
                 %Line.Blank{}
-             ], filename)
+             ], filename())
 
     expected = %Block.Table{
-      header:     ~w{a b c}, 
-      rows:       [ ~w{d e f} ], 
+      header:     ~w{a b c},
+      rows:       [ ~w{d e f} ],
       alignments: [ :right, :center, :left ]}
 
     assert result == [ expected ]
   end
 
 
-  
+
   test "Simple table render" do
     result = Earmark.to_html(["a | b | c", "d | e | f"])
     expected = """
@@ -124,8 +124,8 @@ defmodule TableTest do
     assert result == expected
   end
 
-  defp filename do 
-    "file name" 
+  defp filename do
+    "file name"
   end
 
 end


### PR DESCRIPTION
Mostly Elixir 1.4 "local 0-arity function without parens" warnings, some trailing whitespace and an "unused variable" warning :)