### PR TITLE
Fix hex package

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,8 +43,11 @@ defmodule Earmark.Mixfile do
   defp package do
     [
       files:       [ "lib", "tasks", "mix.exs", "README.md" ],
-      maintainers: [ "Dave Thomas <dave@pragprog.org>"],
-      licenses:    [ "Same as Elixir" ],
+      maintainers: [ 
+                     "Robert Dober <robert.dober@gmail.com>",
+                     "Dave Thomas <dave@pragdave.me>"
+                   ],
+      licenses:    [ "See the file LICENSE" ],
       links:       %{
                        "GitHub" => "https://github.com/pragdave/earmark",
                    }

--- a/mix.exs
+++ b/mix.exs
@@ -42,8 +42,8 @@ defmodule Earmark.Mixfile do
 
   defp package do
     [
-      files:       [ "lib", "tasks", "mix.exs", "README.md" ],
-      maintainers: [ 
+      files:       [ "lib", "src", "tasks", "mix.exs", "README.md" ],
+      maintainers: [
                      "Robert Dober <robert.dober@gmail.com>",
                      "Dave Thomas <dave@pragdave.me>"
                    ],


### PR DESCRIPTION
Hey,

thanks for releasing 1.0, unfortunately I get the following error when using the hex package:

```
** (exit) an exception was raised:
    ** (UndefinedFunctionError) undefined function :string_lexer.string/1 (module :string_lexer is not available)
        :string_lexer.string('This is an example')
        lib/earmark/helpers/lookahead_helpers.ex:62: Earmark.Helpers.LookaheadHelpers.tokenize/1
        lib/earmark/helpers/lookahead_helpers.ex:19: Earmark.Helpers.LookaheadHelpers.opens_inline_code/1
        lib/earmark/block.ex:508: Earmark.Block.inline_or_text?/2
        lib/earmark/block.ex:342: Earmark.Block._consolidate_para/3
        lib/earmark/block.ex:148: Earmark.Block._parse/3
        lib/earmark/block.ex:60: Earmark.Block.lines_to_blocks/2
        lib/earmark/block.ex:51: Earmark.Block.parse/2
        lib/earmark.ex:204: Earmark.parse/2
        lib/earmark.ex:186: Earmark.to_html/2
```

The reason is that the `src` folder is not included in the hex package. This PR fixes that.

Thanks again