### PR TITLE
Correct state abbreviation for Maine to ME

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,20 @@ Github Flavored Markdown tables are supported
         State | Abbrev | Capital
         ----: | :----: | -------
         Texas | TX     | Austin
-        Maine | MN     | Augusta
+        Maine | ME     | Augusta
 
 Tables may have leading and trailing vertical bars on each line
 
         | State | Abbrev | Capital |
         | ----: | :----: | ------- |
         | Texas | TX     | Austin  |
-        | Maine | MN     | Augusta |
+        | Maine | ME     | Augusta |
 
 Tables need not have headers, in which case all column alignments
 default to left.
 
         | Texas | TX     | Austin  |
-        | Maine | MN     | Augusta |
+        | Maine | ME     | Augusta |
 
 Currently we assume there are always spaces around interior vertical
 bars. It isn't clear what the expectation is.


### PR DESCRIPTION
MN is Minnesota and ME is Maine.

P.S. Thanks for making a markdown library in pure elixir!