### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ For example:
 * Rendering of block and inline elements.
 
   Block or void HTML elements that are at the absolute beginning of a line end
-  the preceeding paragraph.
+  the preceding paragraph.
 
   Thusly
 
@@ -175,7 +175,7 @@ For example:
 
 ## Integration
 
-### Syntax Highlightning
+### Syntax Highlighting
 
 All backquoted or fenced code blocks with a language string are rendered with the given
 language as a _class_ attribute of the _code_ tag.
@@ -345,7 +345,7 @@ Where the tuples are of the form `{:error | :warning, line_number, descriptive_t
 #### Plugins, reusing Earmark
 
 As long as you avoid endless recursion there is absolutely no problem to call `Earmark.as_html` in your plugin, consider the following
-example in which the plugin will parse markdown and render html verbatim (which uis stupid, that is what Earmark already does for you,
+example in which the plugin will parse markdown and render html verbatim (which is stupid, that is what Earmark already does for you,
 but just to demonstrate the possibilities):
 
       iex> defmodule Again do


### PR DESCRIPTION
Fixes three typos I noticed in the README