### PR TITLE
Add func parens and remove unsed mod attrs

### DIFF
--- a/lib/earmark/helpers/lookahead_helpers.ex
+++ b/lib/earmark/helpers/lookahead_helpers.ex
@@ -71,7 +71,6 @@ defmodule Earmark.Helpers.LookaheadHelpers do
   end
 
   @type read_list_info :: %{pending: maybe(String.t), pending_lnb: number, initial_indent: number, min_indent: maybe(number)}
-  @not_pending {nil, 0}
   @spec _read_list_lines(Line.ts, Line.ts, read_list_info) :: {boolean, Line.ts, Line.ts, number}
   # List items with initial_indent + 2
   defp _read_list_lines([ line = %Line.ListItem{initial_indent: li_indent} | rest ], [],

--- a/lib/earmark/scanner.ex
+++ b/lib/earmark/scanner.ex
@@ -6,7 +6,6 @@ defmodule Earmark.Scanner do
   @blockquote_rgx ~r/\A>(?!\S)/
   @code_fence_rgx ~r/\A(\s*)~~~/
   @headline_rgx   ~r/\A(\#{1,6})(\s+)(.*)/
-  @id_close_rgx   ~r/\[(.*?)\](?!:)/
   @id_open_rgx    ~r/\A(\s{0,3})\[(.*?)\]:\s+(.*)\z/
   @indent_rgx     ~r/\A\s{4,}/
   @list_item_rgx  ~r/\A(\s{0,3})(\d+\.|\*|-)\s+/

--- a/test/functional/parser/lists_test.exs
+++ b/test/functional/parser/lists_test.exs
@@ -192,6 +192,6 @@ defmodule ListTest do
   end
 
   defp options do
-    %Earmark.Options{file: filename, line: 0}
+    %Earmark.Options{file: filename(), line: 0}
   end
 end

--- a/test/functional/parser/table_test.exs
+++ b/test/functional/parser/table_test.exs
@@ -11,7 +11,7 @@ defmodule TableTest do
                 %Line.Blank{}
              ], options())
 
-    assert result == {[ %Block.Para{lines: ["a | b | c"]} ], options}
+    assert result == {[ %Block.Para{lines: ["a | b | c"]} ], options()}
   end
 
   test "test two table lines make a table" do
@@ -26,7 +26,7 @@ defmodule TableTest do
       alignments: [ :left, :left, :left ],
       header:     nil}
 
-    assert result == {[ expected ], options}
+    assert result == {[ expected ], options()}
   end
 
   test "test heading" do
@@ -42,7 +42,7 @@ defmodule TableTest do
       rows:       [ ~w{d e f} ],
       alignments: [ :left, :left, :left ]}
 
-    assert result == {[ expected ], options}
+    assert result == {[ expected ], options()}
   end
 
   test "test alignment" do

--- a/test/functional/render/footnote_test.exs
+++ b/test/functional/render/footnote_test.exs
@@ -12,7 +12,7 @@ defmodule FootnoteTest do
   end
 
   def options do
-    %Earmark.Options{footnotes: true, file: filename}
+    %Earmark.Options{footnotes: true, file: filename()}
   end
 
   def context do
@@ -160,5 +160,5 @@ defmodule FootnoteTest do
   defp filename do
     "file name"
   end
-  
+
 end

--- a/test/regressions/i051_fenced_code_and_inline_code_test.exs
+++ b/test/regressions/i051_fenced_code_and_inline_code_test.exs
@@ -20,10 +20,6 @@ defmodule Regressions.I051FencedCodeAndInlineCodeTest do
   ```
   """
 
-  @code_inline_to_validate """
-  `term < term :: boolean`
-  """
-
   test"Escape html in text different than in url" do
     result = Earmark.as_html! @url_to_validate
     assert result == """

--- a/test/regressions/i078_escaped_escapes_escape_backtix_test.exs
+++ b/test/regressions/i078_escaped_escapes_escape_backtix_test.exs
@@ -39,18 +39,10 @@ defmodule Regressions.I078EscapedEscapesEscapeBacktixTest do
     # IO.puts html_from_file("test/fixtures/i078_fixed.md")
   end
 
-  @markdown """
-  Hello `\\\\` \\
-      World
-  """
   @short_html """
   <p>Hello <code class="inline">\\\\</code> \\</p>\n<pre><code>World</code></pre>
   """
-  @expected_html """
-  <p>  Notice we had to escape the escape character <code class=\"inline\">\\\\</code>. By giving <code class=\"inline\">\\0</code>,
 
-  <pre><code>  iex&gt; String.replace(&quot;a,b,c&quot;, &quot;b&quot;, &quot;[]&quot;, insert_replaced: 1)\n      &quot;a,[b],c&quot;</code></pre>\n
-  """
   test "Issue https://github.com/pragdave/earmark/issues/78 correct blocks" do
   # assert html_from_file("test/fixtures/i078_short.md") == @expected_html
   # assert (@markdown |> String.split("\n") |> Earmark.Parser.parse()) ==


### PR DESCRIPTION
## Cleaned up 2 things:

1. added parens to function calls w/o parens
1. removed unused module attributes

## Before cleanup

    $ mix test
    Compiling 1 file (.ex)
    warning: module attribute @id_close_rgx was set but never used
      lib/earmark/scanner.ex:9

    Excluding tags: [:wip, :later]

    warning: variable "options" does not exist and is being expanded to "options()", please use parentheses to remove the ambiguity or change the variable name
      test/functional/parser/table_test.exs:14

    warning: variable "options" does not exist and is being expanded to "options()", please use parentheses to remove the ambiguity or change the variable name
      test/functional/parser/table_test.exs:29

    warning: variable "options" does not exist and is being expanded to "options()", please use parentheses to remove the ambiguity or change the variable name
      test/functional/parser/table_test.exs:45

    warning: variable "options" does not exist and is being expanded to "options()", please use parentheses to remove the ambiguity or change the variable name
      test/functional/parser/table_test.exs:61

    warning: variable "filename" does not exist and is being expanded to "filename()", please use parentheses to remove the ambiguity or change the variable name
      test/functional/parser/lists_test.exs:195

    warning: variable "filename" does not exist and is being expanded to "filename()", please use parentheses to remove the ambiguity or change the variable name
      test/functional/render/footnote_test.exs:15

    warning: module attribute @code_inline_to_validate was set but never used
      test/regressions/i051_fenced_code_and_inline_code_test.exs:23

    warning: module attribute @expected_html was set but never used
      test/regressions/i078_escaped_escapes_escape_backtix_test.exs:49

    warning: module attribute @markdown was set but never used
      test/regressions/i078_escaped_escapes_escape_backtix_test.exs:42

    .............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

    Finished in 1.1 seconds
    602 tests, 0 failures, 13 skipped

    Randomized with seed 145687

## After cleanup

    $ mix test
    Compiling 3 files (.erl)
    Compiling 26 files (.ex)
    Generated earmark app
    Excluding tags: [:wip, :later]

    .............................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................

    Finished in 1.0 seconds
    602 tests, 0 failures, 13 skipped

    Randomized with seed 898377