### PR TITLE
Correct as_html docstring with correct return info

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,11 @@ Licensed under the same terms as Elixir, which is Apache 2.0.
 # Details
 <!-- doc: Earmark.as_html -->
 Given a markdown document (as either a list of lines or
-a string containing newlines), returns a tuple containing either
-`{:ok, html_doc}`, or `{:error, html_doc, error_messages}`
-Where `html_doc` is an HTML representation of the markdown document and
-`error_messages` is a list of strings representing information concerning
+a string containing newlines), returns the tuple `{html_doc, error_messages}`
+Where `html_doc` is an HTML representation of the markdown document
+and `error_messages` is a list of strings representing information concerning
 the errors that occurred during parsing.
+`error_messages` will be `[]` if there were no errors.
 
 The options are a `%Earmark.Options{}` structure:
 

--- a/lib/earmark.ex
+++ b/lib/earmark.ex
@@ -238,11 +238,11 @@ defmodule Earmark do
 
   @doc """
   Given a markdown document (as either a list of lines or
-  a string containing newlines), returns a tuple containing either
-  `{:ok, html_doc}`, or `{:error, html_doc, error_messages}`
-  Where `html_doc` is an HTML representation of the markdown document and
-  `error_messages` is a list of strings representing information concerning
+  a string containing newlines), returns the tuple `{html_doc, error_messages}`
+  Where `html_doc` is an HTML representation of the markdown document
+  and `error_messages` is a list of strings representing information concerning
   the errors that occurred during parsing.
+  `error_messages` will be `[]` if there were no errors.
 
   The options are a `%Earmark.Options{}` structure:
 


### PR DESCRIPTION
As far as I can tell, `as_html` doesn't include `:ok` or `:error` atoms in the returned tuple, and always includes the list of errors even if it's empty. It looks like this change happened in 1ef78fe but the docstring for the function wasn't updated alongside the change.