### PR TITLE
Remove deprecation warning from CLI

### DIFF
--- a/lib/earmark/cli.ex
+++ b/lib/earmark/cli.ex
@@ -54,7 +54,7 @@ defmodule Earmark.CLI do
   defp process({io_device, options}) do
     options = struct(Earmark.Options, booleanify(options))
     content = IO.stream(io_device, :line) |> Enum.to_list
-    Earmark.to_html(content, options)
+    Earmark.as_html!(content, options)
     |> IO.puts
   end
 


### PR DESCRIPTION
Using the CLI gave a deprecation warning:

```
./earmark file.md
warning: usage of `Earmark.to_html` is deprecated.
```

This updates to use `Earmark.as_html!/2`