### PR TITLE
Fix crash in warning message generation and bug in reporting

### DIFF
--- a/lib/earmark.ex
+++ b/lib/earmark.ex
@@ -296,7 +296,7 @@ defmodule Earmark do
   @spec as_html(String.t | list(String.t), %Options{}) :: {String.t, list(String.t)}
   def as_html(lines, options \\ %Options{}) do
     html = _as_html(lines, options)
-    case get_all_messages() do
+    case pop_all_messages() do
       []       -> {:ok, html, []}
       messages -> {:error, html, messages}
     end
@@ -312,7 +312,7 @@ defmodule Earmark do
   def as_html!(lines, options \\ %Options{})
   def as_html!(lines, options = %Options{}) do
     html = _as_html(lines, options)
-    emit_messages(options.file, get_all_messages())
+    emit_messages(options.file, pop_all_messages())
     html
   end
 

--- a/lib/earmark/global/messages.ex
+++ b/lib/earmark/global/messages.ex
@@ -5,21 +5,21 @@ defmodule Earmark.Global.Messages do
   and rendering tasks are joined again for the final result.
   """
   @doc false
-  def start_link do 
+  def start_link do
     Agent.start_link(fn -> [] end, name: __MODULE__)
   end
 
   @doc """
-  Retrieve all messages
+  Retrieve all messages and clears the cache for the next file.
   """
-  def get_all_messages do 
-    Agent.get(__MODULE__, &sorted_messages/1)
+  def pop_all_messages do
+    Agent.get_and_update(__MODULE__, &{sorted_messages(&1), []})
   end
 
   @doc """
   Add a message in the format specified
   """
-  def add_message(msg={_severity, lnb, _description}) when is_number(lnb) do 
+  def add_message(msg={_severity, lnb, _description}) when is_number(lnb) do
     Agent.update(__MODULE__, &([msg | &1]))
   end
 
@@ -28,10 +28,10 @@ defmodule Earmark.Global.Messages do
   """
   def add_messages(messages), do: messages |> Enum.each(&add_message/1)
 
-  defp sorted_messages(messages) do 
+  defp sorted_messages(messages) do
     messages
     |> Enum.sort(fn( {_, llnb, _}, {_, rlnb, _}) -> llnb <= rlnb end)
-    |> Enum.uniq()  # This kludge allows an easier implementation of 
+    |> Enum.uniq()  # This kludge allows an easier implementation of
                     # deprecation warnings in 1.2, can be removed in
                     # 1.3
   end

--- a/lib/earmark/global/messages.ex
+++ b/lib/earmark/global/messages.ex
@@ -10,7 +10,7 @@ defmodule Earmark.Global.Messages do
   end
 
   @doc """
-  Retrieve all messages and clears the cache for the next file.
+  Retrieve all messages and clear the cache for the next file.
   """
   def pop_all_messages do
     Agent.get_and_update(__MODULE__, &{sorted_messages(&1), []})

--- a/test/earmark_helpers_tests/attr_parser_test.exs
+++ b/test/earmark_helpers_tests/attr_parser_test.exs
@@ -78,9 +78,9 @@ defmodule EarmarkHelpersTests.AttrParserTest do
     errors = if is_list(errors), do: errors, else: [errors]
     result = parse_attrs( str, 0 )
     assert attrs == result
-    unless Enum.empty?(errors) do 
+    unless Enum.empty?(errors) do
       expected = [{:warning, 0, "Illegal attributes #{inspect errors} ignored in IAL"}]
-      assert M.get_all_messages() == expected
+      assert M.pop_all_messages() == expected
     end
   end
 end

--- a/test/functional/parser/footnotes_test.exs
+++ b/test/functional/parser/footnotes_test.exs
@@ -52,7 +52,7 @@ defmodule Functional.Parser.FootnotesTest do
     [^1]: bar
     """
     test "Shorter Vanilla is not a Footnote" do
-      assert parse(@shorter_vanilla) == 
+      assert parse(@shorter_vanilla) ==
       {[%Earmark.Block.Para{attrs: nil, lnb: 1, lines: ["foo[^1]"]},
         %Earmark.Block.IdDef{attrs: nil, lnb: 3, id: "^1", title: "", url: "bar"}], [{:error, 1, "footnote 1 undefined, reference to it ignored"}]}
 
@@ -71,6 +71,6 @@ defmodule Functional.Parser.FootnotesTest do
 
   defp parse(str) do
     {blocks, _} = Earmark.parse(str, %Options{footnotes: true})
-    {blocks, Earmark.Global.Messages.get_all_messages()}
+    {blocks, Earmark.Global.Messages.pop_all_messages()}
   end
 end

--- a/test/functional/parser/warning_test.exs
+++ b/test/functional/parser/warning_test.exs
@@ -83,8 +83,8 @@ defmodule Parser.WarningTest do
     assert warnings == []
   end
 
-  defp messages_from_parse(str, options \\ %Earmark.Options{}) do 
+  defp messages_from_parse(str, options \\ %Earmark.Options{}) do
     Earmark.parse(str, options)
-    Earmark.Global.Messages.get_all_messages()
+    Earmark.Global.Messages.pop_all_messages()
   end
 end

--- a/test/unit/global/messages_test.exs
+++ b/test/unit/global/messages_test.exs
@@ -9,20 +9,20 @@ defmodule Unit.Global.MessagesTest do
   end
 
   test "empty" do
-    assert M.get_all_messages() == []
+    assert M.pop_all_messages() == []
   end
 
   describe "sequential updates" do
     test "one" do
       M.add_message({:error, 1, "unknown"})
-      assert M.get_all_messages() == [{:error, 1, "unknown"}]
+      assert M.pop_all_messages() == [{:error, 1, "unknown"}]
     end
     test "more" do
       M.add_message({:error, 43, "known"})
       M.add_message({:error, 1, "unknown"})
       M.add_message({:error, 42, "secret"})
 
-      assert M.get_all_messages() == [
+      assert M.pop_all_messages() == [
         {:error, 1, "unknown"},
         {:error, 42, "secret"},
         {:error, 43, "known"},
@@ -44,11 +44,11 @@ defmodule Unit.Global.MessagesTest do
       |> Enum.reverse()
       |> Earmark.pmap(&M.add_message/1)
 
-      assert M.get_all_messages() == expected_messages
+      assert M.pop_all_messages() == expected_messages
     end
 
     test "many with add_message and add_all_messages" do
-      messages = 
+      messages =
       [{:error, 11, "eleven"},
        [{:error, 2, "two"}, {:error, 1, "one"}],
        {:error, 42, "answer"},
@@ -59,11 +59,11 @@ defmodule Unit.Global.MessagesTest do
       messages
       |> Earmark.pmap(&add_message_or_messages/1)
 
-      assert M.get_all_messages() == (
+      assert M.pop_all_messages() == (
         messages
         |> List.flatten()
         |> Enum.sort(&compare/2))
-        
+
     end
   end
 


### PR DESCRIPTION
I can demonstrate the below bugs on C-S-D/retort@8afabf4bb2e04ef83a27a820fff772394cee3883 if you need something to test this against for verification.

# Changelog
## Bug Fixes
* `add_message` calls `Agent.update`, which always returns `:ok`, so it doesn't make sense to use the return value for the new `options1` in `_parse`.  Since both paths shouldn't alter `options`, have the `case` only be run for side-effect of add_message call.

  Fixes this error

  ```
  16:21:23.570 [error] Task #PID<0.512.0> started from #PID<0.70.0> terminating
  ** (BadMapError) expected a map, got: :ok
      (earmark) lib/earmark/block.ex:177: Earmark.Block._parse/3
      (earmark) lib/earmark/block.ex:65: Earmark.Block.lines_to_blocks/2
      (earmark) lib/earmark/block.ex:56: Earmark.Block.parse/2
      (earmark) lib/earmark.ex:337: Earmark.parse/2
      (earmark) lib/earmark.ex:321: Earmark._as_html/2
      (earmark) lib/earmark.ex:314: Earmark.as_html!/2
      (ex_doc) lib/ex_doc/markdown.ex:32: ExDoc.Markdown.to_html/2
      (ex_doc) lib/ex_doc/formatter/html.ex:192:
  ExDoc.Formatter.HTML.build_extra/6
  Function: #Function<14.119834956/0 in
  ExDoc.Formatter.HTML.build_extras/3>
      Args: []
  ```
* The `Agent`'s state in `Earmark.Global.Messages` is never reset, so once a line has a warning it has that warning for all subsequent files.  Since `get_all_messages()` is never called twice to report the same warnings intentionally, `get_all_messages` can be changed to `pop_all_messages`, so it gets the messages as before, but also resets the state, in preparation for the next call.

  This fixes errors like

  ```
  CHANGELOG.md:41: warning: Closing unclosed backquotes ` at end of input
  lib/retort/meta.ex:41: warning: Closing unclosed backquotes ` at end of input
  lib/retort.ex:41: warning: Closing unclosed backquotes ` at end of input
  ```

  where the only the first warning is real, but it is reported on all
  following files. 

## Incompatible Changes
* `Earmark.Global.Messages.get_all_messages/0` is replaced by `Earmark.Global.Messages.pop_all_messages/0` to prevent leaking messages between files.