### PR TITLE
Switched ast function calls from `Earmark.as_ast` to `Earmark.Interfa…

### DIFF
--- a/test/ast/atx_headers_test.exs
+++ b/test/ast/atx_headers_test.exs
@@ -1,6 +1,7 @@
 defmodule Acceptance.AtxHeadersTest do
   use ExUnit.Case
   
+  import Support.Helpers, only: [as_ast: 1, as_ast: 2]
   # describe "ATX headers" do
 
     test "from one to six" do
@@ -9,7 +10,7 @@ defmodule Acceptance.AtxHeadersTest do
       ast = [{"h1", [], ["foo"]}, {"h2", [], ["foo"]}, {"h3", [], ["foo"]}, {"h4", [], ["foo"]}, {"h5", [], ["foo"]}, {"h6", [], ["foo"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "seven? kidding, right?" do
@@ -18,7 +19,7 @@ defmodule Acceptance.AtxHeadersTest do
       ast = {"p", [], ["####### foo"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "sticky (better than to have no glue)" do
@@ -27,7 +28,7 @@ defmodule Acceptance.AtxHeadersTest do
       ast = [{"p", [], ["#5 bolt"]}, {"p", [], ["#foobar"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "close escape" do
@@ -36,7 +37,7 @@ defmodule Acceptance.AtxHeadersTest do
       ast = {"p", [], ["## foo"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "position is so important" do
@@ -45,7 +46,7 @@ defmodule Acceptance.AtxHeadersTest do
       ast = {"h1", [], ["foo ", {"em", [], ["bar"]}, " *baz*"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "spacy" do
@@ -54,7 +55,7 @@ defmodule Acceptance.AtxHeadersTest do
       ast = {"h1", [], ["foo"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "code comes first" do
@@ -63,7 +64,7 @@ defmodule Acceptance.AtxHeadersTest do
       ast = [{"pre", [], [{"code", [], ["# foo"]}]}, {"p", [], ["next"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "some prefer to close their headers" do
@@ -72,7 +73,7 @@ defmodule Acceptance.AtxHeadersTest do
       ast = {"h1", [], ["foo"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "yes, they do (prefer closing their header)" do
@@ -81,7 +82,7 @@ defmodule Acceptance.AtxHeadersTest do
       ast = {"h3", [], ["foo ###"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
   # end

--- a/test/ast/block_ial_test.exs
+++ b/test/ast/block_ial_test.exs
@@ -9,7 +9,7 @@ defmodule Acceptance.BlockIalTest do
       ast = {"p", [], ["{:hello=world}"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "Not associated means verbatim" do
@@ -18,7 +18,7 @@ defmodule Acceptance.BlockIalTest do
       ast = {"p", [], ["{: hello=world  }"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "Not associated and incorrect" do
@@ -27,7 +27,7 @@ defmodule Acceptance.BlockIalTest do
       ast = {"p", [], ["{:hello}"]}
       messages = [{:warning, 1, "Illegal attributes [\"hello\"] ignored in IAL" }]
 
-      assert Earmark.as_ast(markdown) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:error, ast, messages}
     end
 
     test "Associated" do
@@ -36,7 +36,7 @@ defmodule Acceptance.BlockIalTest do
       ast = {"p", [{"hello", "world"}], ["Before"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "Associated in between" do
@@ -45,7 +45,7 @@ defmodule Acceptance.BlockIalTest do
       ast = [{"p", [{"hello", "world"}], ["Before"]}, {"p", [], ["After"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "Associated and incorrect" do
@@ -54,7 +54,7 @@ defmodule Acceptance.BlockIalTest do
       ast = {"p", [], ["Before"]}
       messages = [{:warning, 2, "Illegal attributes [\"hello\"] ignored in IAL" }]
 
-      assert Earmark.as_ast(markdown) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:error, ast, messages}
     end
 
     test "Associated and partly incorrect" do
@@ -63,7 +63,7 @@ defmodule Acceptance.BlockIalTest do
       ast = {"p", [{"title", "world"}], ["Before"]}
       messages = [{:warning, 2, "Illegal attributes [\"hello\"] ignored in IAL" }]
 
-      assert Earmark.as_ast(markdown) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:error, ast, messages}
     end
 
     test "Associated and partly incorrect and shortcuts" do
@@ -72,7 +72,7 @@ defmodule Acceptance.BlockIalTest do
       ast = {"p", [{"class", "gamma beta alpha"}, {"id", "hello"}, {"title", "class world"}], ["Before"]}
       messages = [{:warning, 2, "Illegal attributes [\"hello\"] ignored in IAL" }]
 
-      assert Earmark.as_ast(markdown) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:error, ast, messages}
     end
 
   end

--- a/test/ast/block_quotes_test.exs
+++ b/test/ast/block_quotes_test.exs
@@ -8,7 +8,7 @@ defmodule Acceptance.BlockQuotesTest do
       ast = {"blockquote", [], [{"p", [], ["Foo"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "and block my quotes" do
@@ -17,7 +17,7 @@ defmodule Acceptance.BlockQuotesTest do
       ast = {"blockquote", [], [{"h1", [], ["Foo"]}, {"p", [], ["barbaz"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "linient we are" do
@@ -26,7 +26,7 @@ defmodule Acceptance.BlockQuotesTest do
       ast = {"blockquote", [], [{"p", [], ["barbazfoo"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "lists in blockquotes? Coming up Sir" do
@@ -35,7 +35,7 @@ defmodule Acceptance.BlockQuotesTest do
       ast = [{"blockquote", [], [{"ul", [], [{"li", [], ["foo"]}]}]}, {"ul", [], [{"li", [], ["bar"]}]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
   # end

--- a/test/ast/diverse_test.exs
+++ b/test/ast/diverse_test.exs
@@ -10,7 +10,7 @@ defmodule Acceptance.DiverseTest do
       ast = {"p", [], [{"code", [{"class", "inline"}], ["f&amp;ouml;&amp;ouml;"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "spaec preserving" do
@@ -19,7 +19,7 @@ defmodule Acceptance.DiverseTest do
       ast = {"p", [], ["Multiple     spaces"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "syntax errors" do
@@ -28,7 +28,7 @@ defmodule Acceptance.DiverseTest do
       ast = [{"p", [], ["A\nB"]}, {"p", [], []}]
       messages = [{:warning, 3, "Unexpected line =" }]
 
-      assert Earmark.as_ast(markdown) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:error, ast, messages}
     end
    end
 

--- a/test/ast/emphasis_test.exs
+++ b/test/ast/emphasis_test.exs
@@ -10,7 +10,7 @@ defmodule Acceptance.EmphasisTest do
       ast = {"p", [], [{"em", [], ["foo bar"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "imporatant quotes" do
@@ -19,7 +19,7 @@ defmodule Acceptance.EmphasisTest do
       ast = {"p", [], ["a", {"em", [], ["&quot;foo&quot;"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown, smartypants: false) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown, smartypants: false) == {:ok, ast, messages}
     end
 
     test "important _" do
@@ -28,7 +28,7 @@ defmodule Acceptance.EmphasisTest do
       ast = {"p", [], [{"em", [], ["foo bar"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "dont get confused" do
@@ -37,7 +37,7 @@ defmodule Acceptance.EmphasisTest do
       ast = {"p", [], ["_foo*"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "that should make you smile" do
@@ -46,7 +46,7 @@ defmodule Acceptance.EmphasisTest do
       ast = {"p", [], [{"em", [], ["foo_bar_baz"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "stronger" do
@@ -55,7 +55,7 @@ defmodule Acceptance.EmphasisTest do
       ast = {"p", [], [{"strong", [], ["foo bar"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "stronger insisde" do
@@ -64,7 +64,7 @@ defmodule Acceptance.EmphasisTest do
       ast = {"p", [], ["foo", {"strong", [], ["bar"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "stronger together" do
@@ -73,7 +73,7 @@ defmodule Acceptance.EmphasisTest do
       ast = {"p", [], [{"strong", [], ["foo bar"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "let no evil underscores divide us" do
@@ -82,7 +82,7 @@ defmodule Acceptance.EmphasisTest do
       ast = {"p", [], [{"strong", [], ["foo__bar"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "strong **and** stronger" do
@@ -91,7 +91,7 @@ defmodule Acceptance.EmphasisTest do
       ast = {"p", [], [{"em", [], ["(", {"strong", [], ["foo"]}, ")"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "stronger **and** strong" do
@@ -100,7 +100,7 @@ defmodule Acceptance.EmphasisTest do
       ast = {"p", [], [{"strong", [], ["(", {"em", [], ["foo"]}, ")"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "one is not strong enough" do
@@ -109,7 +109,7 @@ defmodule Acceptance.EmphasisTest do
       ast = {"p", [], ["foo*"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
   # end

--- a/test/ast/escape_test.exs
+++ b/test/ast/escape_test.exs
@@ -10,11 +10,11 @@ defmodule Acceptance.EscapeTest do
       ast = {"p", [], ["\\!\\“"]}
       messages = []
 
-      assert Earmark.as_ast(markdown, smartypants: true) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown, smartypants: true) == {:ok, ast, messages}
 
       # html     = "<p>\\!\\&quot;</p>\n"
       ast = {"p", [], ["\\!\\&quot;"]}
-      assert Earmark.as_ast(markdown, smartypants: false) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown, smartypants: false) == {:ok, ast, messages}
     end
 
     test "obviously" do
@@ -23,7 +23,7 @@ defmodule Acceptance.EscapeTest do
       ast = {"p", [], ["`no code"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "less obviously - escpe the escapes" do
@@ -32,7 +32,7 @@ defmodule Acceptance.EscapeTest do
       ast = {"p", [], ["\\", {"code", [{"class", "inline"}], ["code"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "don't ask me" do
@@ -41,7 +41,7 @@ defmodule Acceptance.EscapeTest do
       ast = {"p", [], ["\\ \\"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "a plenty of nots" do
@@ -50,7 +50,7 @@ defmodule Acceptance.EscapeTest do
       ast = {"p", [], ["*not emphasized*\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a header\n[foo]: /url &quot;not a reference&quot;"]}
       messages = [{:warning, 3, "Closing unclosed backquotes ` at end of input" }]
 
-      assert Earmark.as_ast(markdown, smartypants: false) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown, smartypants: false) == {:error, ast, messages}
     end
 
     test "let us escape (again)" do
@@ -58,7 +58,7 @@ defmodule Acceptance.EscapeTest do
       # html = "<p>\\<em>emphasis</em></p>\n"
       ast = {"p", [], ["\\", {"em", [], ["emphasis"]}]}
       messages = []
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
   # end
 end

--- a/test/ast/fenced_code_blocks_test.exs
+++ b/test/ast/fenced_code_blocks_test.exs
@@ -8,7 +8,7 @@ defmodule Acceptance.FencedCodeBlocksTest do
       ast = {"pre", [], [{"code", [{"class", ""}], ["&lt;\n &gt;"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "still no lang" do
@@ -17,7 +17,7 @@ defmodule Acceptance.FencedCodeBlocksTest do
       ast = {"pre", [], [{"code", [{"class", ""}], ["&lt;\n &gt;"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "elixir 's the name" do
@@ -26,7 +26,7 @@ defmodule Acceptance.FencedCodeBlocksTest do
       ast = {"pre", [], [{"code", [{"class", "elixir"}], ["aaa~~~"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "with a code_class_prefix" do
@@ -35,7 +35,7 @@ defmodule Acceptance.FencedCodeBlocksTest do
       ast = {"pre", [], [{"code", [{"class", "elixir lang-elixir"}], ["aaa~~~"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown, code_class_prefix: "lang-") == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown, code_class_prefix: "lang-") == {:ok, ast, messages}
     end
 
     test "look mam, more lines" do
@@ -44,7 +44,7 @@ defmodule Acceptance.FencedCodeBlocksTest do
       ast = {"pre", [], [{"code", [{"class", ""}], ["aaa\nb"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
   # end

--- a/test/ast/footnotes_test.exs
+++ b/test/ast/footnotes_test.exs
@@ -9,7 +9,7 @@ defmodule Acceptance.FootnotesTest do
       ast = [{"p", [],  ["foo",   {"a",    [{"href", "#fn:1"}, {"id", "fnref:1"}, {"class", "footnote"},     {"title", "see footnote"}], ["1"]}, " again"]}, {"div", [{"class", "footnotes"}],  [{"hr", [], []},   {"ol", [],    [{"li", [{"id", "fn:1"}],      [{"p", [],        ["bar baz&nbsp;",         {"a",          [{"href", "#fnref:1"}, {"title", "return to article"},           {"class", "reversefootnote"}], ["&#x21A9;"]}]}]}]}]}]
       messages = []
 
-      assert Earmark.as_ast(markdown, footnotes: true) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown, footnotes: true) == {:ok, ast, messages}
     end
 
     test "undefined footnotes" do
@@ -18,7 +18,7 @@ defmodule Acceptance.FootnotesTest do
       ast = {"p", [], ["foo[^1]\nhello"]}
       messages = [{:error, 1, "footnote 1 undefined, reference to it ignored"}]
 
-      assert Earmark.as_ast(markdown, footnotes: true) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown, footnotes: true) == {:error, ast, messages}
     end
 
     test "undefined footnotes (none at all)" do
@@ -27,7 +27,7 @@ defmodule Acceptance.FootnotesTest do
       ast = {"p", [], ["foo[^1]\nhello"]}
       messages = [{:error, 1, "footnote 1 undefined, reference to it ignored"}]
 
-      assert Earmark.as_ast(markdown, footnotes: true) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown, footnotes: true) == {:error, ast, messages}
     end
 
     test "illdefined footnotes" do
@@ -38,7 +38,7 @@ defmodule Acceptance.FootnotesTest do
         {:error, 1, "footnote 1 undefined, reference to it ignored"},
         {:error, 4, "footnote 1 undefined, reference to it ignored"}]
 
-      assert Earmark.as_ast(markdown, footnotes: true) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown, footnotes: true) == {:error, ast, messages}
     end
 
 

--- a/test/ast/horizontal_rules_test.exs
+++ b/test/ast/horizontal_rules_test.exs
@@ -9,7 +9,7 @@ defmodule Acceptance.HorizontalRulesTest do
       ast = [{"hr", [{"class", "thick"}], []}, {"hr", [{"class", "thin"}], []}, {"hr", [{"class", "medium"}], []}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "not a rule" do
@@ -18,7 +18,7 @@ defmodule Acceptance.HorizontalRulesTest do
       ast = {"p", [], ["+++"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "not in code" do
@@ -27,7 +27,7 @@ defmodule Acceptance.HorizontalRulesTest do
       ast = {"pre", [], [{"code", [], ["***\n\n a"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "not in code, second line" do
@@ -36,7 +36,7 @@ defmodule Acceptance.HorizontalRulesTest do
       ast = [{"p", [], ["Foo"]}, {"pre", [], [{"code", [], ["***"]}]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "medium, long" do
@@ -45,7 +45,7 @@ defmodule Acceptance.HorizontalRulesTest do
       ast = {"hr", [{"class", "medium"}], []}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "emmed, so to speak" do
@@ -54,7 +54,7 @@ defmodule Acceptance.HorizontalRulesTest do
       ast = {"p", [], [{"em", [], ["-"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "in lists" do
@@ -63,7 +63,7 @@ defmodule Acceptance.HorizontalRulesTest do
       ast = [{"ul", [], [{"li", [], ["foo"]}]}, {"hr", [{"class", "thick"}], []}, {"ul", [], [{"li", [], ["bar"]}]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "setext rules over rules (why am I soo witty?)" do
@@ -72,7 +72,7 @@ defmodule Acceptance.HorizontalRulesTest do
       ast = [{"h2", [], ["Foo"]}, {"p", [], ["bar"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "in lists, thick this time (why am I soo good to you?)" do
@@ -80,7 +80,7 @@ defmodule Acceptance.HorizontalRulesTest do
       # html = "<ul>\n<li>Foo\n</li>\n</ul>\n<hr class=\"thick\"/>\n<ul>\n<li>Bar\n</li>\n</ul>\n"
       ast = [{"ul", [], [{"li", [], ["Foo"]}]}, {"hr", [{"class", "thick"}], []}, {"ul", [], [{"li", [], ["Bar"]}]}]
       messages = []
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
   # end
 end

--- a/test/ast/html_test.exs
+++ b/test/ast/html_test.exs
@@ -8,7 +8,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = [{"table", [], [{"tr", [], [{"td", [], ["           hi    "]}]}]}, {"p", [], ["okay."]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "div (ine?)" do
@@ -17,7 +17,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = {"div", [], ["  *hello*         ", {"foo", [], [{"a", [], []}]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "we are leaving html alone" do
@@ -26,7 +26,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = {"div", [], ["*Emphasized* text."]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
   # end
@@ -38,7 +38,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = [{"area",  [{"shape", "rect"}, {"coords", "0,0,1,1"}, {"href", "xxx"}, {"alt", "yyy"}],  []}, {"p", [], [{"strong", [], ["emphasized"]}, " text"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "we are outside the void now (lucky us)" do
@@ -47,7 +47,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = [{"br", [], []}, {"p", [], [{"strong", [], ["emphasized"]}, " text"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "high regards???" do
@@ -56,7 +56,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = [{"hr", [], []}, {"p", [], [{"strong", [], ["emphasized"]}, " text"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "img (a punless test)" do
@@ -65,7 +65,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = [{"img", [{"src", "hello"}], []}, {"p", [], [{"strong", [], ["emphasized"]}, " text"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "not everybode knows this one (hint: take a break)" do
@@ -73,7 +73,7 @@ defmodule Acceptance.HtmlBlocksTest do
       # html = "<wbr><p><strong>emphasized</strong> text</p>\n"
       ast = {"wbr", [], [{"p", [], [{"strong", [], ["emphasized"]}, " text"]}]}
       messages = []
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
   # end
 
@@ -84,7 +84,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = [{"p", [], ["alpha"]}, {"hr", [], []}, "beta"]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "void elements close para but only at BOL" do
@@ -93,7 +93,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = {"p", [], ["alpha ", {"hr", [], []}, "beta"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "self closing block elements close para" do
@@ -102,7 +102,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = [{"p", [], ["alpha"]}, {"div", [], []}, "beta"]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "self closing block elements close para, atts do not matter" do
@@ -111,7 +111,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = [{"p", [], ["alpha"]}, {"div", [{"class", "first"}], []}, "beta"]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "self closing block elements close para, atts and spaces do not matter" do
@@ -120,7 +120,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = [{"p", [], ["alpha"]}, {"div", [{"class", "first"}], []}, "beta", {"p", [], ["gamma"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "self closing block elements close para but only at BOL" do
@@ -129,7 +129,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = {"p", [], ["alpha ", {"div", [], []}, "beta"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "self closing block elements close para but only at BOL, atts do not matter" do
@@ -138,7 +138,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = {"p", [], ["alpha\ngamma", {"div", [{"class", "fourty two"}], []}, "beta"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "block elements close para" do
@@ -147,7 +147,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = [{"p", [], ["alpha"]}, {"div", [], []}, "beta"]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "block elements close para, atts do not matter" do
@@ -156,7 +156,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = [{"p", [], ["alpha"]}, {"div", [{"class", "first"}], []}, "beta"]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "block elements close para but only at BOL" do
@@ -165,7 +165,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = {"p", [], ["alpha\n ", {"div", [], []}, "beta"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "block elements close para but only at BOL, atts do not matter" do
@@ -174,7 +174,7 @@ defmodule Acceptance.HtmlBlocksTest do
       ast = {"p", [], ["alpha\ngamma", {"div", [{"class", "fourty two"}], []}, "beta"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
   # end

--- a/test/ast/indented_code_blocks_test.exs
+++ b/test/ast/indented_code_blocks_test.exs
@@ -8,7 +8,7 @@ defmodule Acceptance.IndentedCodeBlocksTest do
       ast = {"pre", [], [{"code", [], ["a simple\n  indented code block"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "code is soo verbatim" do
@@ -17,7 +17,7 @@ defmodule Acceptance.IndentedCodeBlocksTest do
       ast = {"pre", [], [{"code", [], ["&lt;a/&gt;*hi*\n\n- one"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "chunky bacon (RIP: Why)" do
@@ -26,7 +26,7 @@ defmodule Acceptance.IndentedCodeBlocksTest do
       ast = {"pre", [], [{"code", [], ["chunk1\n\nchunk2\n\n\nchunk3"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "foo and bar (now you are surprised!)" do
@@ -35,7 +35,7 @@ defmodule Acceptance.IndentedCodeBlocksTest do
       ast = [{"pre", [], [{"code", [], ["foo"]}]}, {"p", [], ["bar"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "not the alpha, not the omega (gamma maybe?)" do
@@ -43,7 +43,7 @@ defmodule Acceptance.IndentedCodeBlocksTest do
       # html = "<pre><code>foo</code></pre>\n"
       ast = {"pre", [], [{"code", [], ["foo"]}]}
       messages = []
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
   # end
 end

--- a/test/ast/inline_code_test.exs
+++ b/test/ast/inline_code_test.exs
@@ -9,7 +9,7 @@ defmodule Acceptance.InlineCodeTest do
       ast = {"p", [], [{"code", [{"class", "inline"}], ["foo"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "plain simple, right?" do
@@ -18,7 +18,7 @@ defmodule Acceptance.InlineCodeTest do
       ast = {"p", [], [{"code", [{"class", "inline"}], ["hi"]}, "lo`"]}
       messages = [{:warning, 1, "Closing unclosed backquotes ` at end of input"}]
 
-      assert Earmark.as_ast(markdown) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:error, ast, messages}
     end
 
     test "this time you got it right" do
@@ -27,7 +27,7 @@ defmodule Acceptance.InlineCodeTest do
       ast = {"p", [], [{"code", [{"class", "inline"}], ["ab"]}, "c"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "and again!!!" do
@@ -35,7 +35,7 @@ defmodule Acceptance.InlineCodeTest do
       # html = "<ul>\n<li><code class=\"inline\">a `\n`\n b</code>c\n</li>\n</ul>\n"
       ast = {"ul", [], [{"li", [], [{"code", [{"class", "inline"}], ["a `\n`\n b"]}, "c"]}]}
       messages = []
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
   # end
 end

--- a/test/ast/inline_ial_test.exs
+++ b/test/ast/inline_ial_test.exs
@@ -9,7 +9,7 @@ defmodule Acceptance.InlineIalTest do
       ast = {"p", [], [{"a", [{"href", "url"}, {"class", "classy"}], ["link"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "img with simple ial" do
@@ -18,7 +18,7 @@ defmodule Acceptance.InlineIalTest do
       ast = {"p", [], [{"img", [{"src", "url"}, {"alt", "link"}, {"id", "thatsme"}], []}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     # A side effect
@@ -28,7 +28,7 @@ defmodule Acceptance.InlineIalTest do
       ast = {"p", [], [{"span", [{"xi", "ypsilon"}, {"alpha", "beta"}, {"class", "greek"}],   ["τι κανις"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "not attached" do
@@ -37,7 +37,7 @@ defmodule Acceptance.InlineIalTest do
       ast = {"p", [], [{"a", [{"href", "url"}, {"lang", "fr"}], ["link"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
   end
 
@@ -48,7 +48,7 @@ defmodule Acceptance.InlineIalTest do
       ast = {"p", [], [{"a", [{"href", "url"}], ["link"]}]}
       messages = [{:warning, 1, "Illegal attributes [\"incorrect\"] ignored in IAL" }]
 
-      assert Earmark.as_ast(markdown) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:error, ast, messages}
     end
 
     test "illegal format line two" do
@@ -57,7 +57,7 @@ defmodule Acceptance.InlineIalTest do
       ast = {"p", [], ["a line", {"a", [{"href", "url"}, {"x", "y"}], ["link"]}]}
       messages = [{:warning, 2, "Illegal attributes [\"incorrect\"] ignored in IAL" }]
 
-      assert Earmark.as_ast(markdown) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:error, ast, messages}
     end
   end
 

--- a/test/ast/link_and_img_test.exs
+++ b/test/ast/link_and_img_test.exs
@@ -9,7 +9,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"a", [{"href", "/url"}, {"title", "title"}], ["foo"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "this ain't no link" do
@@ -18,7 +18,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], ["[bar]"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "img with title" do
@@ -27,7 +27,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"img", [{"src", "/url"}, {"alt", "foo"}, {"title", "title"}], []}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "this ain't no img (and no link)" do
@@ -36,7 +36,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], ["![bar]"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "strange syntaxes exist in Markdown" do
@@ -45,7 +45,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"a", [{"href", "url"}, {"title", ""}], ["foo"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "sometimes strange text is just strange text" do
@@ -54,11 +54,11 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], ["[foo]: /url &quot;title&quot; ok"]}
       messages = []
 
-      assert Earmark.as_ast(markdown, smartypants: false) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown, smartypants: false) == {:ok, ast, messages}
 
       # html     = "<p>[foo]: /url “title” ok</p>\n"
       ast = {"p", [], ["[foo]: /url “title” ok"]}
-      assert Earmark.as_ast(markdown, smartypants: true) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown, smartypants: true) == {:ok, ast, messages}
     end
 
     test "guess how this one is rendered?" do
@@ -67,7 +67,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = []
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "or this one, but you might be wrong" do
@@ -76,7 +76,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = [{"h1", [], [{"a", [{"href", "/url"}, {"title", ""}], ["Foo"]}]}, {"blockquote", [], [{"p", [], ["bar"]}]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
   end
@@ -89,7 +89,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = []
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "inner is a link, not outer" do
@@ -98,7 +98,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], ["[", {"a", [{"href", "inner"}], ["text"]}, "]outer"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "unless your outer is syntactically a link of course" do
@@ -107,7 +107,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"a", [{"href", "outer"}], ["[text](inner)"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "as with this img" do
@@ -116,7 +116,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"img", [{"src", "outer"}, {"alt", "[text](inner)"}], []}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "headaches ahead (and behind us)" do
@@ -125,7 +125,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"a", [{"href", "/uri"}], [{"img", [{"src", "moon.jpg"}, {"alt", "moon"}], []}]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "lost in space" do
@@ -133,7 +133,7 @@ defmodule Acceptance.LinkAndImgTest do
       # html = "<p><img src=\"sun.jpg\" alt=\"![moon](moon.jpg)\"/></p>\n"
       ast = {"p", [], [{"img", [{"src", "sun.jpg"}, {"alt", "![moon](moon.jpg)"}], []}]}
       messages = []
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
   end
 
@@ -144,7 +144,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"a", [{"href", "/uri"}, {"title", "title"}], ["link"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "titled link, with depreacted quote missmatch" do
@@ -153,7 +153,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"a", [{"href", "/uri"}, {"title", "title"}], ["link"]}]}
       messages = [{:warning, 1, "deprecated, missmatching quotes will not be parsed as matching in v1.3"}]
 
-      assert Earmark.as_ast(markdown) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:error, ast, messages}
     end
 
     test "no title" do
@@ -162,7 +162,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"a", [{"href", "/uri"}], ["link"]}, ")"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "let's go nowhere" do
@@ -171,7 +171,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"a", [{"href", ""}], ["link"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "nowhere in a bottle" do
@@ -179,7 +179,7 @@ defmodule Acceptance.LinkAndImgTest do
       # html = "<p><a href=\"()\">link</a></p>\n"
       ast = {"p", [], [{"a", [{"href", "()"}], ["link"]}]}
       messages = []
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
   end
 
@@ -190,7 +190,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"img", [{"src", "/url"}, {"alt", "foo"}, {"title", "title"}], []}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "ti tle (why not)" do
@@ -199,7 +199,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"img", [{"src", "/url"}, {"alt", "foo"}, {"title", "ti tle"}], []}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "titles become strange" do
@@ -208,7 +208,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"img", [{"src", "/url"}, {"alt", "foo"}, {"title", "ti() tle"}], []}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "as does everything else" do
@@ -217,7 +217,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"img", [{"src", "/url"}, {"alt", "f[]oo"}, {"title", "ti() tle"}], []}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "alt goes crazy" do
@@ -226,7 +226,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"img", [{"src", "/url"}, {"alt", "foo[([])]"}, {"title", "title"}], []}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "alt goes crazy, with deprecation warnings" do
@@ -235,7 +235,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"img", [{"src", "/url"}, {"alt", "foo[([])]"}, {"title", "title"}], []}]}
       messages = [{:warning, 2, "deprecated, missmatching quotes will not be parsed as matching in v1.3"}]
 
-      assert Earmark.as_ast(markdown) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:error, ast, messages}
     end
 
     test "url escapes of course" do
@@ -244,7 +244,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"img", [{"src", "/url%20no%20title"}, {"alt", "foo"}], []}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
   end
@@ -256,7 +256,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"a", [{"href", "http://foo.bar.baz"}], ["http://foo.bar.baz"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "as was this" do
@@ -265,7 +265,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"a", [{"href", "irc://foo.bar:2233/baz"}], ["irc://foo.bar:2233/baz"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "good ol' mail" do
@@ -274,7 +274,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"a", [{"href", "mailto:foo@bar.baz"}], ["foo@bar.baz"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "we know what mail is" do
@@ -283,7 +283,7 @@ defmodule Acceptance.LinkAndImgTest do
       ast = {"p", [], [{"a", [{"href", "mailto:foo@bar.example.com"}], ["foo@bar.example.com"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "not really a link" do
@@ -291,7 +291,7 @@ defmodule Acceptance.LinkAndImgTest do
       # html = "<p>&lt;&gt;</p>\n"
       ast = {"p", [], ["&lt;&gt;"]}
       messages = []
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
   end

--- a/test/ast/list_indent_test.exs
+++ b/test/ast/list_indent_test.exs
@@ -9,7 +9,7 @@ defmodule Acceptance.ListIndentTest do
       ast = {"ol", [], [{"li", [],   [{"p", [], ["One"]}, {"ol", [{"start", "2"}], [{"li", [], ["two"]}]}]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "mixed two levels (by 2)" do
@@ -18,7 +18,7 @@ defmodule Acceptance.ListIndentTest do
       ast = {"ol", [], [{"li", [],   [{"p", [], ["One"]},    {"ul", [], [{"li", [], ["two"]}, {"li", [], ["three"]}]}]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "mixed two levels (by 4)" do
@@ -27,7 +27,7 @@ defmodule Acceptance.ListIndentTest do
       ast = {"ol", [], [{"li", [],   [{"p", [], ["One"]},    {"ul", [], [{"li", [], ["two"]}, {"li", [], ["three"]}]}]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "2 level correct pop up" do
@@ -36,7 +36,7 @@ defmodule Acceptance.ListIndentTest do
       ast = {"ul", [], [{"li", [],   [{"p", [], ["1"]},    {"ul", [],     [{"li", [], [{"p", [], ["1.1"]}, {"ul", [], [{"li", [], ["1.1.1"]}]}]},      {"li", [], ["1.2"]}]}]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "mixed level correct pop up" do
@@ -45,7 +45,7 @@ defmodule Acceptance.ListIndentTest do
       ast = {"ul", [], [{"li", [],   [{"p", [], ["1"]},    {"ul", [],     [{"li", [], [{"p", [], ["1.1"]}, {"ul", [], [{"li", [], ["1.1.1"]}]}]},      {"li", [], ["1.2"]}]}]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "4 level correct pop up" do
@@ -54,7 +54,7 @@ defmodule Acceptance.ListIndentTest do
       ast = {"ul", [], [{"li", [],   [{"p", [], ["1"]},    {"ul", [],     [{"li", [], [{"p", [], ["1.1"]}, {"ul", [], [{"li", [], ["1.1.1"]}]}]},      {"li", [], ["1.2"]}]}]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
   end
 end

--- a/test/ast/list_test.exs
+++ b/test/ast/list_test.exs
@@ -8,7 +8,7 @@ defmodule Acceptance.ListTest do
       ast = {"ul", [], [{"li", [], ["one"]}, {"li", [], ["two"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "Unnumbered Indented" do
@@ -17,7 +17,7 @@ defmodule Acceptance.ListTest do
       ast = {"ul", [], [{"li", [], ["one"]}, {"li", [], ["two"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "Unnumbered Indent taken into account" do
@@ -26,7 +26,7 @@ defmodule Acceptance.ListTest do
       ast = {"ul", [], [{"li", [], ["one one.one"]}, {"li", [], ["two"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
 
     end
     test "Numbered" do
@@ -35,7 +35,7 @@ defmodule Acceptance.ListTest do
       ast = {"ol", [], [{"li", [],   [{"p", [], ["A paragraphwith two lines."]},    {"pre", [], [{"code", [], ["indented code"]}]},    {"blockquote", [], [{"p", [], ["A block quote."]}]}]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "More numbers" do
@@ -44,7 +44,7 @@ defmodule Acceptance.ListTest do
       ast = {"ol", [], [{"li", [], [{"p", [], ["space one"]}]},  {"li", [], [{"p", [], ["space two"]}]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "can't count" do
@@ -53,7 +53,7 @@ defmodule Acceptance.ListTest do
       ast = [{"ul", [], [{"li", [], ["one"]}]}, {"p", [], [" two"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "still not" do
@@ -62,7 +62,7 @@ defmodule Acceptance.ListTest do
       ast = {"ul", [], [{"li", [], ["one"]}, {"li", [], ["two"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "the second one is not one" do
@@ -71,7 +71,7 @@ defmodule Acceptance.ListTest do
       ast = {"ol", [], [{"li", [], ["one"]}, {"li", [], ["two"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "where shall we start" do
@@ -80,7 +80,7 @@ defmodule Acceptance.ListTest do
       ast = {"ol", [{"start", "2"}], [{"li", [], ["one\n"]}, {"li", [], ["two"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "one?" do
@@ -89,7 +89,7 @@ defmodule Acceptance.ListTest do
       ast = {"ol", [{"start", "2"}], [{"li", [], ["one\n"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "count or no count?" do
@@ -98,7 +98,7 @@ defmodule Acceptance.ListTest do
       ast = [{"p", [], ["-one"]}, {"p", [], ["2.two"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "list or no list?" do
@@ -107,7 +107,7 @@ defmodule Acceptance.ListTest do
       ast = {"p", [], ["-1. not ok"]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "no count or count?" do
@@ -116,7 +116,7 @@ defmodule Acceptance.ListTest do
       ast = {"ol", [], [{"li", [], ["foobar"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "where does it end?" do
@@ -125,7 +125,7 @@ defmodule Acceptance.ListTest do
       ast = {"ul", [], [{"li", [], ["a\nb\nc"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "tables in lists? Maybe not" do
@@ -134,7 +134,7 @@ defmodule Acceptance.ListTest do
       ast = {"ul", [], [{"li", [], ["x\na\n| A | B |"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "nice try, but naah" do
@@ -143,7 +143,7 @@ defmodule Acceptance.ListTest do
       ast = {"ul", [], [{"li", [], ["x\n | A | B |"]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
   end

--- a/test/ast/paragraphs_test.exs
+++ b/test/ast/paragraphs_test.exs
@@ -8,7 +8,7 @@ defmodule Acceptance.ParagraphsTest do
       ast = [{"p", [], ["aaa"]}, {"p", [], ["bbb"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "and another one" do
@@ -17,7 +17,7 @@ defmodule Acceptance.ParagraphsTest do
       ast = [{"p", [], ["aaa"]}, {"p", [], ["bbb"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
   end

--- a/test/ast/setext_headers_test.exs
+++ b/test/ast/setext_headers_test.exs
@@ -9,7 +9,7 @@ defmodule Acceptance.SetextHeadersTest do
       ast = [{"h1", [], ["Foo ", {"em", [], ["bar"]}]}, {"h2", [], ["Foo ", {"em", [], ["bar"]}]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "and levels two and one" do
@@ -18,7 +18,7 @@ defmodule Acceptance.SetextHeadersTest do
       ast = [{"h2", [], ["Foo"]}, {"h1", [], ["Foo"]}]
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "narrow escape" do
@@ -26,7 +26,7 @@ defmodule Acceptance.SetextHeadersTest do
       # html = "<h2>Foo\\</h2>\n"
       ast = {"h2", [], ["Foo\\"]}
       messages = []
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
   end

--- a/test/ast/structural_test.exs
+++ b/test/ast/structural_test.exs
@@ -9,7 +9,7 @@ defmodule Acceptance.StructuralTest do
       ast = {"table", [], [{"colgroup", [], [{"col", [], []}, {"col", [], []}, {"col", [], []}]},  {"tr", [],   [{"td", [{"style", "text-align: left"}], ["a"]},    {"td", [{"style", "text-align: left"}], ["b"]},    {"td", [{"style", "text-align: left"}], ["c"]}]},  {"tr", [],   [{"td", [{"style", "text-align: left"}], ["d"]},    {"td", [{"style", "text-align: left"}], ["e"]},    {"td", [{"style", "text-align: left"}],     [{"a", [{"href", "url"}, {"target", "blank"}], ["link"]}]}]}]}
       messages = []
 
-      assert Earmark.as_ast(markdown) == {:ok, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:ok, ast, messages}
     end
 
     test "table with link with inline ial, errors" do 
@@ -19,7 +19,7 @@ defmodule Acceptance.StructuralTest do
       ast = {"table", [], [{"colgroup", [], [{"col", [], []}, {"col", [], []}, {"col", [], []}]},  {"tr", [],   [{"td", [{"style", "text-align: left"}], ["a"]},    {"td", [{"style", "text-align: left"}], ["b"]},    {"td", [{"style", "text-align: left"}], ["c"]}]},  {"tr", [],   [{"td", [{"style", "text-align: left"}], ["d"]},    {"td", [{"style", "text-align: left"}], ["e"]},    {"td", [{"style", "text-align: left"}],     [{"a", [{"href", "url"}, {"target", "blank"}], ["link"]}]}]}]}
       messages = [{:warning, 2, "Illegal attributes [\"xxx\"] ignored in IAL"}]
 
-      assert Earmark.as_ast(markdown) == {:error, ast, messages}
+      assert Earmark.Interface.html(markdown) == {:error, ast, messages}
     end
   end
 end


### PR DESCRIPTION
Updated all AST acceptance tests to use the function `Earmark.Interface.html` instead of `Earmark.as_ast` as previously setup