### PR TITLE
Fix elixir 1.5 compile warnings

### DIFF
--- a/lib/earmark/helpers.ex
+++ b/lib/earmark/helpers.ex
@@ -16,7 +16,7 @@ defmodule Earmark.Helpers do
   Remove newlines at end of line
   """
   def remove_line_ending(line) do
-    line |> String.rstrip(?\n) |> String.rstrip(?\r)
+    line |> String.trim_trailing("\n") |> String.trim_trailing("\r")
   end
 
   defp pad(1), do: " "

--- a/lib/earmark/helpers/leex_helpers.ex
+++ b/lib/earmark/helpers/leex_helpers.ex
@@ -5,7 +5,7 @@ defmodule Earmark.Helpers.LeexHelpers do
   """
   def lex text, with: lexer do
     case text
-      |> String.to_char_list()
+      |> String.to_charlist()
       |> lexer.string() do
         {:ok, tokens, _} -> tokens
       end
@@ -14,7 +14,7 @@ defmodule Earmark.Helpers.LeexHelpers do
   def tokenize line, with: lexer do
     {:ok, tokens, _} =
     line
-    |> to_char_list()
+    |> to_charlist()
     |> lexer.string()
     elixirize_tokens(tokens,[])
     |> Enum.reverse()

--- a/lib/earmark/helpers/link_parser.ex
+++ b/lib/earmark/helpers/link_parser.ex
@@ -83,7 +83,7 @@ defmodule Earmark.Helpers.LinkParser do
   end
 
   defp depreactions(string, lnb) do 
-   with stripped <- String.strip(string),
+   with stripped <- String.trim(string),
         opening  <- String.first(stripped),
         closing  <- String.last(stripped), do: _deprecations(opening, closing, lnb)
   end

--- a/lib/earmark/inline.ex
+++ b/lib/earmark/inline.ex
@@ -198,7 +198,7 @@
   defp converter_for_code({src, context, result, lnb}, renderer) do
     if match = Regex.run(context.rules.code, src) do
       [match, _, content] = match
-      content = String.strip(content)  # this from Gruber
+      content = String.trim(content)  # this from Gruber
       out = renderer.codespan(escape(content, true))
       { behead(src, match), context, prepend(result,  out), lnb }
     end

--- a/lib/earmark/line.ex
+++ b/lib/earmark/line.ex
@@ -126,7 +126,7 @@ defmodule Earmark.Line do
 
       match = Regex.run(~R/^(#{1,6})\s+(?|([^#]+)#*$|(.*))/u, line) ->
         [ _, level, heading ] = match
-        %Heading{level: String.length(level), content: String.strip(heading) }
+        %Heading{level: String.length(level), content: String.trim(heading) }
 
       match = Regex.run(~r/^>(?|(\s*)$|\s(.*))/, line) ->
         [ _, quote ] = match
@@ -191,8 +191,8 @@ defmodule Earmark.Line do
       match = Regex.run(~r/^ \s{0,3} \| (?: [^|]+ \|)+ \s* $ /x, line) ->
         [ body ] = match
         body = body
-               |> String.strip
-               |> String.strip(?|)
+               |> String.trim
+               |> String.trim("|")
         columns = split_table_columns(body)
         %TableLine{content: line, columns: columns}
 
@@ -207,7 +207,7 @@ defmodule Earmark.Line do
 
       match = Regex.run(~r<^\s{0,3}{:(\s*[^}]+)}\s*$>, line) ->
         [ _, ial ] = match
-        %Ial{attrs: String.strip(ial), verbatim: ial}
+        %Ial{attrs: String.trim(ial), verbatim: ial}
 
       match = Regex.run(~r<^\$\$(\w*)$>, line) ->
         [_, prefix] = match
@@ -230,7 +230,7 @@ defmodule Earmark.Line do
   defp split_table_columns(line) do
     line
     |> String.split(~r{(?<!\\)\|})
-    |> Enum.map(&String.strip/1)
+    |> Enum.map(&String.trim/1)
     |> Enum.map(fn col -> Regex.replace(~r{\\\|}, col, "|") end)
   end
 

--- a/test/earmark_helpers_tests/lookahead/link_parser_test.exs
+++ b/test/earmark_helpers_tests/lookahead/link_parser_test.exs
@@ -17,35 +17,35 @@ defmodule EarmarkHelpersTests.Lookahead.LinkParserTest do
   end
   test "text with escapes" do
     str = "[hello\\[]"
-    assert {'hello[', String.to_char_list(str)} == parse(str)
+    assert {'hello[', String.to_charlist(str)} == parse(str)
   end
   test "text with many parts" do
     str = "[hello( world\\])]"
-    assert {'hello( world])', String.to_char_list(str)} == parse(str)
+    assert {'hello( world])', String.to_charlist(str)} == parse(str)
   end
   test "simple imbrication" do
     str = "[[hello]]"
-    assert {'[hello]', String.to_char_list(str)} == parse(str)
+    assert {'[hello]', String.to_charlist(str)} == parse(str)
   end
   test "complex imbrication" do
     str = "[pre[iniside]suff]"
-    assert {'pre[iniside]suff', String.to_char_list(str)} == parse(str)
+    assert {'pre[iniside]suff', String.to_charlist(str)} == parse(str)
   end
   test "deep imbrication" do
     str = "[pre[[in\\]]side])]"
-    assert {'pre[[in]]side])', String.to_char_list(str)} == parse(str)
+    assert {'pre[[in]]side])', String.to_charlist(str)} == parse(str)
   end
   test "with quotes" do
     str = ~s<["hello']>
-    assert {'"hello\'', String.to_char_list(str)} == parse(str)
+    assert {'"hello\'', String.to_charlist(str)} == parse(str)
   end
   test "with open_title token" do
     str = ~s<[hello "world"]>
-    assert {'hello "world"', String.to_char_list(str)} == parse(str)
+    assert {'hello "world"', String.to_charlist(str)} == parse(str)
   end
   test "with quotes and escapes" do
     str = ~s<["hell\\o']>
-    assert {'"hello\'', String.to_char_list(str)} == parse("#{str}(url\\))")
+    assert {'"hello\'', String.to_charlist(str)} == parse("#{str}(url\\))")
   end
   test "missing closing brackets" do
     assert nil ==  parse("[pre[[in\\]side])]")

--- a/test/regressions/i103_nested_unclosed_tags_test.exs
+++ b/test/regressions/i103_nested_unclosed_tags_test.exs
@@ -21,6 +21,6 @@ defmodule Regressions.I103NestedUnclosedTagsTest do
       <no file>:1: warning: Failed to find closing <x>
       <no file>:3: warning: Failed to find closing <y>
       <no file>:6: warning: Failed to find closing <z>
-      """ |> String.lstrip()
+      """ |> String.trim_leading()
   end
 end

--- a/test/support/error_plugin.ex
+++ b/test/support/error_plugin.ex
@@ -1,11 +1,11 @@
 defmodule Support.ErrorPlugin do
-  
-  def as_html(lines) do 
+
+  def as_html(lines) do
     if Enum.all?(lines, &correct?/1) do
       "<strong>correct</strong>\n"
     else
-      { Enum.filter_map(lines, &correct?/1, fn _ -> "<strong>correct</strong>" end),
-        Enum.filter_map(lines, &(!correct?(&1)), &make_error/1)}
+      { for line <- lines, correct?(line) do "<strong>correct</strong>" end,
+        for line <- lines, !correct?(line) do make_error(line) end }
     end
   end
 


### PR DESCRIPTION
Howdy!

Mostly just replacing `strip`/`lstrip`/`rstrip`/`to_char_list` with the newer versions to fix Elixir 1.5 compile warnings. Also convert `Enum.filter_map/3` to a list comprehension for the same reason.