### PR TITLE
Fix deprecation warnings about Enum.partition

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ Where the tuples are of the form `{:error | :warning, line_number, descriptive_t
       ...>   end
       ...>
       ...>   defp render(lines) do
-      ...>     Enum.map(lines, &render_line/1) |> Enum.partition(&ok?/1)
+      ...>     Enum.map(lines, &render_line/1) |> Enum.split_with(&ok?/1)
       ...>   end
       ...>
       ...>   defp render_line({"", _}), do: "<hr/>"

--- a/lib/earmark/parser.ex
+++ b/lib/earmark/parser.ex
@@ -20,7 +20,7 @@ defmodule Earmark.Parser do
 
   # @spec handle_footnotes( Block.ts, %Earmark.Options{}, ( Block.ts,
   def handle_footnotes(blocks, options, map_func) do
-    { footnotes, blocks } = Enum.partition(blocks, &footnote_def?/1)
+    { footnotes, blocks } = Enum.split_with(blocks, &footnote_def?/1)
     { footnotes, undefined_footnotes } =
       map_func.(blocks, &find_footnote_links/1)
         |> List.flatten()
@@ -72,7 +72,7 @@ defmodule Earmark.Parser do
 
   defp create_footnote_blocks(blocks, footnotes) do
     lnb = footnotes
-      |> Stream.map(&(&1.lnb)) 
+      |> Stream.map(&(&1.lnb))
       |> Enum.min()
     footnote_block = %Block.FnList{blocks: Enum.sort_by(footnotes, &(&1.number)), lnb: lnb}
     Enum.concat(blocks, [footnote_block])

--- a/lib/earmark/plugin.ex
+++ b/lib/earmark/plugin.ex
@@ -59,7 +59,7 @@ defmodule Earmark.Plugin do
         ...>   end
         ...>
         ...>   defp render(lines) do
-        ...>     Enum.map(lines, &render_line/1) |> Enum.partition(&ok?/1)
+        ...>     Enum.map(lines, &render_line/1) |> Enum.split_with(&ok?/1)
         ...>   end
         ...>
         ...>   defp render_line({"", _}), do: "<hr/>"


### PR DESCRIPTION
`Enum.partition` was deprecated in favor of `Enum.split_with`.

For reference: https://github.com/elixir-lang/elixir/issues/4996