### PR TITLE
Typespec fixes + Fix to Earmark.Context.clear/1

### DIFF
--- a/lib/earmark/context.ex
+++ b/lib/earmark/context.ex
@@ -6,7 +6,7 @@ defmodule Earmark.Context do
   @type t :: %__MODULE__{
     options: Earmark.Options.t,
     links: map(),
-    rules: Keyword.t(),
+    rules: Keyword.t() | nil,
     footnotes: map(),
     value: String.t | [String.t]
   }

--- a/lib/earmark/context.ex
+++ b/lib/earmark/context.ex
@@ -3,6 +3,14 @@ defmodule Earmark.Context do
   use Earmark.Types
   import Earmark.Helpers
 
+  @type t :: %__MODULE__{
+    options: Earmark.Options.t,
+    links: map(),
+    rules: Keyword.t(),
+    footnotes: map(),
+    value: String.t | [String.t]
+  }
+
   defstruct options:  %Earmark.Options{},
             links:    Map.new,
             rules:    nil,

--- a/lib/earmark/context.ex
+++ b/lib/earmark/context.ex
@@ -41,7 +41,7 @@ defmodule Earmark.Context do
   def clear(%__MODULE__{} = ctx) do
     ctx
     |> set_value([])
-    put_in(ctx.options.messages, [])
+    |> put_in([:options, :messages], [])
   end
 
   @doc false

--- a/lib/earmark/helpers/attr_parser.ex
+++ b/lib/earmark/helpers/attr_parser.ex
@@ -7,7 +7,7 @@ defmodule Earmark.Helpers.AttrParser do
 
   @type errorlist :: list(String.t)
 
-  @spec parse_attrs(Context.t, String.t, number()) :: {Map.t, errorlist}
+  @spec parse_attrs(Context.t, String.t, number()) :: {map, errorlist}
   def parse_attrs(context, attrs, lnb) do
     { attrs, errors } = _parse_attrs(%{}, attrs, [], lnb)
     { add_errors(context, errors, lnb), attrs }
@@ -55,5 +55,5 @@ defmodule Earmark.Helpers.AttrParser do
 
   defp add_errors(context, [], _lnb), do: context
   defp add_errors(context, errors, lnb), do: add_message(context, {:warning, lnb, "Illegal attributes #{inspect errors} ignored in IAL"})
-    
+
 end

--- a/lib/earmark/options.ex
+++ b/lib/earmark/options.ex
@@ -1,5 +1,7 @@
 defmodule Earmark.Options do
 
+  @type t :: %__MODULE__{}
+
   # What we use to render
   defstruct  renderer: Earmark.HtmlRenderer,
              # Inline style options

--- a/lib/earmark/types.ex
+++ b/lib/earmark/types.ex
@@ -4,7 +4,7 @@ defmodule Earmark.Types do
     quote do
       @type token  :: {atom, String.t}
       @type tokens :: list(token)
-      @type numbered_line :: %{line: String.t, lnb: number}
+      @type numbered_line :: %{required(:line) => String.t, required(:lnb) => number, optional(:inside_code) => String.t}
       @type message_type :: :warning | :error
       @type message :: {message_type, number, String.t}
       @type maybe(t) :: t | nil


### PR DESCRIPTION
Added some `@type`s and resolved a few typspec errors (`Map.t` not existing, e.g.).

While doing so, I noticed `Earmark.Context.clear/1` was not piping the context through to `put_in/3` so it was losing the clearing of `value`. Not sure what bugs that caused for others, but I'm not sure that has worked properly. 