### PR TITLE
Fix for IAL on inline code

### DIFF
--- a/lib/earmark/helpers/html_helpers.ex
+++ b/lib/earmark/helpers/html_helpers.ex
@@ -8,8 +8,13 @@ defmodule Earmark.Helpers.HtmlHelpers do
 
   def augment_tag_with_ial(context, tag, ial, lnb) do 
     case Regex.run( @simple_tag, tag) do 
-      nil -> nil
-      _   -> add_attrs(context, tag, ial, [], lnb)
+      nil ->
+        nil
+      ["<code class=\"inline\">", "code class=\"inline\""] ->
+        tag = String.replace(tag, ~s{ class="inline"}, "")
+        add_attrs(context, tag, ial, [{"class", ["inline"]}], lnb)
+      _   ->
+        add_attrs(context, tag, ial, [], lnb)
     end
     
   end
@@ -40,7 +45,8 @@ defmodule Earmark.Helpers.HtmlHelpers do
   defp add_attrs(context, text, attrs, default, _lnb) do
     {context, 
       default
-      |> Enum.into(attrs)
+      |> Map.new()
+      |> Map.merge(attrs, fn _k, v1, v2 -> v1 ++ v2 end)
       |> attrs_to_string()
       |> add_to(text)}
   end

--- a/test/acceptance/inline_ial_test.exs
+++ b/test/acceptance/inline_ial_test.exs
@@ -12,6 +12,14 @@ defmodule Acceptance.InlineIalTest do
       assert as_html(markdown) == {:ok, html, messages}
     end
 
+    test "code with simple ial" do
+      markdown = "`some code`{: .classy}"
+      html     = "<p><code class=\"inline classy\">some code</code></p>\n"
+      messages = []
+
+      assert as_html(markdown) == {:ok, html, messages}
+    end
+
     test "img with simple ial" do
       markdown = "![link](url){:#thatsme}"
       html     = "<p><img src=\"url\" alt=\"link\" id=\"thatsme\"/></p>\n" 


### PR DESCRIPTION
See: https://github.com/pragdave/earmark/issues/194

Seems like the `default` attrs in `Earmark.Helpers.HtmlHelpers. add_attrs` should be a string map as well, but I left it as it seems to require some more far reaching refactoring.