### PR TITLE
Add start_heading_level option for the parser

### DIFF
--- a/lib/earmark.ex
+++ b/lib/earmark.ex
@@ -375,6 +375,21 @@ defmodule Earmark do
 
          ```
 
+    - `start_heading_level: 1`
+         ```elixir
+          Earmark.as_html("# this is a heading", start_heading_level: 1)
+          {:ok,
+            "<h1>this is a heading</h1\\n>", []}
+
+          Earmark.as_html("# this is a heading", start_heading_level: 2)
+          {:ok,
+            "<h2>this is a heading</h2>\\n", []}
+
+          Earmark.as_html("# this is a heading", start_heading_level: 2)
+          {:ok,
+            "<h3>this is a heading</h3>\\n", []}
+         ```
+
   """
   def as_html(lines, options \\ %Options{})
   def as_html(lines, options) when is_list(options) do

--- a/lib/earmark.ex
+++ b/lib/earmark.ex
@@ -385,7 +385,7 @@ defmodule Earmark do
           {:ok,
             "<h2>this is a heading</h2>\\n", []}
 
-          Earmark.as_html("# this is a heading", start_heading_level: 2)
+          Earmark.as_html("## this is a heading", start_heading_level: 2)
           {:ok,
             "<h3>this is a heading</h3>\\n", []}
          ```

--- a/lib/earmark/line_scanner.ex
+++ b/lib/earmark/line_scanner.ex
@@ -102,8 +102,11 @@ defmodule Earmark.LineScanner do
         %Line.Ruler{type: "_"}
 
       match = Regex.run(~R/^(#{1,6})\s+(?|([^#]+)#*$|(.*))/u, line) ->
-        [_, level, heading] = match
-        %Line.Heading{level: String.length(level), content: String.trim(heading)}
+        [_, desired_level, heading] = match
+        level =
+          min((options.start_heading_level - 1) + String.length(desired_level), 6)
+
+        %Line.Heading{level: level, content: String.trim(heading)}
 
       match = Regex.run(~r/^>(?|(\s*)$|\s(.*))/, line) ->
         [_, quote] = match

--- a/lib/earmark/options.ex
+++ b/lib/earmark/options.ex
@@ -18,6 +18,9 @@ defmodule Earmark.Options do
             # Add possibility to specify a timeout for Task.await
             timeout: nil,
 
+            # Be able to specify at what level headings start
+            start_heading_level: 1,
+
             # Internal—only override if you're brave
             do_smartypants: nil,
             do_sanitize: nil,

--- a/test/functional/parser/heading_test.exs
+++ b/test/functional/parser/heading_test.exs
@@ -14,6 +14,17 @@ defmodule Parser.HeadingTest do
     assert result == [%Block.Heading{content: "Heading", level: 1, lnb: 2}]
   end
 
+  test "Start heading option is respected" do
+    result = Earmark.as_html!("# test", %Earmark.Options{start_heading_level: 2})
+    expected = "<h2>test</h2>\n"
+    assert result == expected
+  end
+
+  test "Default start heading option is 1" do
+    result = Earmark.as_html!("# test", %Earmark.Options{})
+    expected = "<h1>test</h1>\n"
+    assert result == expected
+  end
 end
 
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This adds the option `:start_heading_level` to configure at what level the headings start.

The use case for this is when we output HTML in a page as user-generated content and there's already a `h1`, we don't want to have duplicated `h1` headings in the page. Instead we want to shift all headers by 1.

Usage:

```elixir
Earmark.as_html("# this is a heading", start_heading_level: 1)
{:ok,
  "<h1>this is a heading</h1\\n>", []}

Earmark.as_html("# this is a heading", start_heading_level: 2)
{:ok,
  "<h2>this is a heading</h2>\\n", []}

Earmark.as_html("## this is a heading", start_heading_level: 2)
{:ok,
  "<h3>this is a heading</h3>\\n", []}
```
