### PR TITLE
Refactor README.md toc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 * [Dependency](#dependency)
 * [Usage](#usage)
 * [Details](#details)
-* [`Earmark.as_html/2`](#`earmark.as_html/2`)
-* [`Earmark.as_ast/2`](#`earmark.as_ast/2`)
-* [`Earmark.Transform.transform/2`](#`earmark.transform.transform/2`)
+* [`Earmark.as_html/2`](#earmarkas_html2)
+* [`Earmark.as_ast/2`](#earmarkas_ast2)
+* [`Earmark.Transform.transform/2`](#earmarktransformtransform2)
 * [Contributing](#contributing)
 * [Author](#author)
 <!-- END generated TOC -->
@@ -447,7 +447,8 @@ Therefore `as_ast` is of the following type
 ## `Earmark.Transform.transform/2`
 
 <!-- BEGIN inserted functiondoc Earmark.Transform.transform/2 -->
-**EXPERIMENTAL**, but well tested, just expect API changes in the 1.4 branch
+**EXPERIMENTAL**
+But well tested, just expect API changes in the 1.4 branch
 Takes an ast, and optional options (I love this pun), which can be
 a map or keyword list of which the following keys will be used:
 

--- a/tasks/readme.exs
+++ b/tasks/readme.exs
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Readme do
 
   defp add_doc(line) do
     [ "<!-- BEGIN inserted #{line} -->",
-      line 
+      line
       |> String.split()
       |> doc_for(),
       "<!-- END inserted #{line} -->" ]
@@ -102,12 +102,12 @@ defmodule Mix.Tasks.Readme do
     end
   end
 
-  defp make_h2_anchor(title), do: title |> String.downcase() |> String.replace(~r{\s+}, "-")
+  defp make_h2_anchor(title), do: title |> String.downcase() |> String.replace(~r{\s+}, "-") |> String.replace(~r{[^\w-]}, "")
 
   defp make_toc_entry(title), do: "* [#{title}](##{make_h2_anchor(title)})"
 
   defp make_toc_string(tocs),
-    do: 
+    do:
       [ "<!-- BEGIN generated TOC -->",
         tocs |> Enum.join("\n"),
         "<!-- END generated TOC -->"


### PR DESCRIPTION
The README table of contents links are broken for a few of the entries, e.g. "Earmark.as_html/2". This PR strips out invalid characters to get the links working again.

[**Updated README.md**](https://github.com/raygesualdo/earmark/blob/c25ff31d337f42bde90dc1402d582f94b00c0595/README.md)