### PR TITLE
Remove duplicate struct field definition

### DIFF
--- a/lib/earmark/line.ex
+++ b/lib/earmark/line.ex
@@ -76,7 +76,7 @@ defmodule Earmark.Line do
 
   defmodule SetextUnderlineHeading  do
     @moduledoc false
-    defstruct(lnb: 0, line: "", level: 1, inside_code: false, inside_code: false)
+    defstruct(lnb: 0, line: "", level: 1, inside_code: false)
   end
 
   defmodule TableLine  do


### PR DESCRIPTION
Elixir v1.10 will also warn in such cases.