### PR TITLE
Smartypants: Convert three hyphens to em dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Where `html_doc` is an HTML representation of the markdown document and
 * `smartypants`: boolean
 
   Turns on smartypants processing, so quotes become curly, two
-  or four hyphens become en and em dashes, and so on. True by
+  or three hyphens become en and em dashes, and so on. True by
   default.
 
   So, to format the document in `original` and disable smartypants,

--- a/bench/simple_data_bench.exs
+++ b/bench/simple_data_bench.exs
@@ -386,7 +386,7 @@ defmodule Bench.SimpleDataBench do
   * `smartypants`: boolean
 
     Turns on smartypants processing, so quotes become curly, two
-    or four hyphens become en and em dashes, and so on. True by
+    or three hyphens become en and em dashes, and so on. True by
     default.
 
     So, to format the document in `original` and disable smartypants,

--- a/lib/earmark.ex
+++ b/lib/earmark.ex
@@ -326,7 +326,7 @@ defmodule Earmark do
   * `smartypants`: boolean
 
     Turns on smartypants processing, so quotes become curly, two
-    or four hyphens become en and em dashes, and so on. True by
+    or three hyphens become en and em dashes, and so on. True by
     default.
 
     So, to format the document in `original` and disable smartypants,

--- a/lib/earmark/transform.ex
+++ b/lib/earmark/transform.ex
@@ -141,16 +141,18 @@ defmodule Earmark.Transform do
       if void?, do: " />", else: ">"
     ["<", tag, atts |> Enum.map(&make_att(&1, tag)), closer]
   end
-  
-  @dashes_rgx ~r{--}
-  @dbl1_rgx ~r{(^|[-—/\(\[\{"”“\s])'}
+
+  @em_dash_rgx ~r{---}
+  @en_dash_rgx ~r{--}
+  @dbl1_rgx ~r{(^|[-–—/\(\[\{"”“\s])'}
   @single_rgx ~r{\'}
-  @dbl2_rgx ~r{(^|[-—/\(\[\{‘\s])\"}
+  @dbl2_rgx ~r{(^|[-–—/\(\[\{‘\s])\"}
   @dbl3_rgx ~r{"}
   defp smartypants(text, options)
   defp smartypants(text, %{smartypants: true}) do
     text
-    |> replace(@dashes_rgx, "—")
+    |> replace(@em_dash_rgx, "—")
+    |> replace(@en_dash_rgx, "–")
     |> replace(@dbl1_rgx, "\\1‘")
     |> replace(@single_rgx, "’")
     |> replace(@dbl2_rgx, "\\1“")

--- a/test/acceptance/html/render_specific/smarty_pants_test.exs
+++ b/test/acceptance/html/render_specific/smarty_pants_test.exs
@@ -1,6 +1,8 @@
 defmodule Acceptance.Html.RenderSpecific.SmartyPantsTest do
   use Support.AcceptanceTestCase
 
+  @en_dash          "\u2013"
+  @em_dash          "\u2014"
   @open_sgl_smarty  "\u2018"
   @close_sgl_smarty "\u2019"
   @open_dbl_smarty  "\u201c"
@@ -30,7 +32,7 @@ defmodule Acceptance.Html.RenderSpecific.SmartyPantsTest do
 
       assert as_html(markdown) == {:ok, html, messages}
     end
-    test "paired single" do 
+    test "paired single" do
       markdown = "a 'single' quote"
       html     = para("a #{sgl_quote("single")} quote")
       messages = []
@@ -63,8 +65,24 @@ defmodule Acceptance.Html.RenderSpecific.SmartyPantsTest do
 
       assert as_html(markdown) == {:ok, html, messages}
     end
+
+    test "en dash" do
+      markdown = "1947 -- 2020"
+      html     = para("1947 #{@en_dash} 2020")
+      messages = []
+
+      assert as_html(markdown) == {:ok, html, messages}
+    end
+
+    test "em dash" do
+      markdown = "Earmark---A Pure Elixir Markdown Processor"
+      html     = para("Earmark#{@em_dash}A Pure Elixir Markdown Processor")
+      messages = []
+
+      assert as_html(markdown) == {:ok, html, messages}
+    end
   end
-  
-  defp dbl_quote(str), do: Enum.join([@open_dbl_smarty, str, @close_dbl_smarty]) 
-  defp sgl_quote(str), do: Enum.join([@open_sgl_smarty, str, @close_sgl_smarty]) 
+
+  defp dbl_quote(str), do: Enum.join([@open_dbl_smarty, str, @close_dbl_smarty])
+  defp sgl_quote(str), do: Enum.join([@open_sgl_smarty, str, @close_sgl_smarty])
 end

--- a/test/fixtures/elixir_readmes.md
+++ b/test/fixtures/elixir_readmes.md
@@ -1147,7 +1147,7 @@ Where `html_doc` is an HTML representation of the markdown document and
 * `smartypants`: boolean
 
   Turns on smartypants processing, so quotes become curly, two
-  or four hyphens become en and em dashes, and so on. True by
+  or three hyphens become en and em dashes, and so on. True by
   default.
 
   So, to format the document in `original` and disable smartypants,


### PR DESCRIPTION
This was documented but not implemented. The documentation said it should happen with four hyphens, but [the original Smartypants docs](https://daringfireball.net/projects/smartypants/) say three hyphens so I went with that and updated the documentation.