### PR TITLE
Remove application/0 from mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -50,9 +50,7 @@ defmodule Earmark.Mixfile do
   end
 
   def application do
-    [
-      applications: [ :earmark_parser ]
-    ]
+    []
   end
 
   defp package do

--- a/mix.exs
+++ b/mix.exs
@@ -49,10 +49,6 @@ defmodule Earmark.Mixfile do
     ]
   end
 
-  def application do
-    []
-  end
-
   defp package do
     [
       files: [


### PR DESCRIPTION
Since [Elixir v1.4 introduced "application inference"](https://github.com/elixir-lang/elixir/blob/v1.4/CHANGELOG.md#application-inference) we don't need to manually set :applications, as it's inferred from deps. In fact, setting :applications explicitly can be harmful because it overrides inference, so if you add another dep but forget to update this list, that application won't be part of the release. That's exactly the reason for the recent bug, setting `applications: []` was overriding inference.