### PR TITLE
Support for "wikilink" style links

### DIFF
--- a/lib/earmark/ast/inline.ex
+++ b/lib/earmark/ast/inline.ex
@@ -306,7 +306,8 @@ defmodule Earmark.Ast.Inline do
   end
 
   defp output_wikilink(context, text, href, title, lnb) do
-    output_link(context, text, href, title, lnb)
+    {tag, attrs, body} = output_link(context, text, href, title, lnb)
+    {tag, [{"class", "wikilink"} | attrs], body}
   end
 
   defp reference_link(context, match, alt_text, id, lnb) do

--- a/lib/earmark/ast/inline.ex
+++ b/lib/earmark/ast/inline.ex
@@ -108,8 +108,9 @@ defmodule Earmark.Ast.Inline do
       {match1, text, href, title, link_or_img} = match
       out =
         case link_or_img do
-          :link  -> output_link(context, text, href, title, lnb)
-          :image -> render_image(text, href, title)
+          :link     -> output_link(context, text, href, title, lnb)
+          :wikilink -> output_wikilink(context, text, href, title, lnb)
+          :image    -> render_image(text, href, title)
         end
       {behead(src, match1), lnb, prepend(context, out), use_linky?}
     end
@@ -302,6 +303,10 @@ defmodule Earmark.Ast.Inline do
     else
       { "a", [{"href", href}], Enum.reverse(context2.value) }
     end
+  end
+
+  defp output_wikilink(context, text, href, title, lnb) do
+    output_link(context, text, href, title, lnb)
   end
 
   defp reference_link(context, match, alt_text, id, lnb) do

--- a/lib/earmark/helpers/link_parser.ex
+++ b/lib/earmark/helpers/link_parser.ex
@@ -98,7 +98,17 @@ defmodule Earmark.Helpers.LinkParser do
     end
   end
 
+  @wikilink_rgx ~r{\A\[\[([^\]\|]+)(?:\|([^\]]+))?\]\]\Z}
+  defp make_result(nil, _, parsed_text, :link) do
+    case Regex.run(@wikilink_rgx, parsed_text) do
+      nil -> nil
+      [_, wikilink] -> make_wikilink(parsed_text, wikilink, wikilink)
+      [_, wikilink, link_text] -> make_wikilink(parsed_text, wikilink, link_text)
+    end
+  end
+
   defp make_result(nil, _, _, _), do: nil
+
   defp make_result({parsed, url, title}, link_text, parsed_text, link_or_img) do
     {"#{parsed_text}(#{list_to_text(parsed)})", link_text, list_to_text(url), title, link_or_img}
   end
@@ -107,6 +117,10 @@ defmodule Earmark.Helpers.LinkParser do
 
   defp add_title({parsed_text, url_text, _}, {parsed, inner}),
     do: {[parsed | parsed_text], url_text, inner}
+
+  defp make_wikilink(parsed_text, target, link_text) do
+    {parsed_text, String.trim(link_text), String.trim(target), nil, :wikilink}
+  end
 
   defp list_to_text(lst), do: lst |> Enum.reverse() |> Enum.join("")
 end

--- a/test/acceptance/ast/links_images/wiki_links_test.exs
+++ b/test/acceptance/ast/links_images/wiki_links_test.exs
@@ -1,0 +1,42 @@
+defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
+  use ExUnit.Case, async: true
+  import Support.Helpers, only: [as_ast: 1, parse_html: 1]
+
+  describe "Wiki links" do
+    test "basic wiki-style link" do
+      markdown = "[[page]]"
+      html = "<p><a href=\"page\">page</a></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+
+    test "misleading non-wiki link" do
+      markdown = "[[page]](actual_link)"
+      html = "<p><a href=\"actual_link\">[page]</a></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+
+    test "alternate text" do
+      markdown = "[[page | My Label]]"
+      html = "<p><a href=\"page\">My Label</a></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+
+    test "illegal urls are not Earmark's responsability" do
+      markdown = "[[A long & complex title]]"
+      html = "<p><a href=\"A long & complex title\">A long &amp; complex title</a></p>\n"
+      ast      = parse_html(html)
+      messages = []
+
+      assert as_ast(markdown) == {:ok, [ast], messages}
+    end
+  end
+end

--- a/test/acceptance/ast/links_images/wiki_links_test.exs
+++ b/test/acceptance/ast/links_images/wiki_links_test.exs
@@ -5,7 +5,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
   describe "Wiki links" do
     test "basic wiki-style link" do
       markdown = "[[page]]"
-      html = "<p><a href=\"page\">page</a></p>\n"
+      html = "<p><a class=\"wikilink\" href=\"page\">page</a></p>\n"
       ast      = parse_html(html)
       messages = []
 
@@ -23,7 +23,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
 
     test "alternate text" do
       markdown = "[[page | My Label]]"
-      html = "<p><a href=\"page\">My Label</a></p>\n"
+      html = "<p><a class=\"wikilink\" href=\"page\">My Label</a></p>\n"
       ast      = parse_html(html)
       messages = []
 
@@ -32,7 +32,7 @@ defmodule Acceptance.Ast.LinkImages.WikiLinksTest do
 
     test "illegal urls are not Earmark's responsability" do
       markdown = "[[A long & complex title]]"
-      html = "<p><a href=\"A long & complex title\">A long &amp; complex title</a></p>\n"
+      html = "<p><a class=\"wikilink\" href=\"A long & complex title\">A long &amp; complex title</a></p>\n"
       ast      = parse_html(html)
       messages = []
 


### PR DESCRIPTION
This is commonly used in markdown based wikis (for example, Github's wiki).

