### PR TITLE
Use SPDX license identifier in hex metadata

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -61,7 +61,7 @@ defmodule Earmark.Mixfile do
         "Dave Thomas <dave@pragdave.me>"
       ],
       licenses: [
-        "Apache 2 (see the file LICENSE for details)"
+        "Apache-2.0"
       ],
       links: %{
         "GitHub" => "https://github.com/pragdave/earmark"


### PR DESCRIPTION
Per https://hex.pm/docs/publish

>   A list of licenses the project is licensed under. This attribute is required. It is recommended to use SPDX License identifier.

It allows other tools to use spdx identifier for audit.