### PR TITLE
Handle inline code smartypants

### DIFF
--- a/lib/earmark/transform.ex
+++ b/lib/earmark/transform.ex
@@ -34,6 +34,12 @@ defmodule Earmark.Transform do
   defp _to_html({:comment, _, content, _}, _options, _level, _verbatim) do
     "<!--#{content |> Enum.intersperse("\n")}-->\n"
   end
+  defp _to_html({"code", atts, children, meta}, options, level, _verbatim) do
+    verbatim = meta |> Map.get(:verbatim, false)
+    [ open_tag("code", atts),
+      _to_html(children, Map.put(options, :smartypants, false), level, verbatim),
+      "</code>"]
+  end
   defp _to_html({tag, atts, children, _}, options, level, verbatim) when tag in @compact_tags do
     [open_tag(tag, atts),
        children
@@ -68,7 +74,7 @@ defmodule Earmark.Transform do
       _to_html(children, options, level+1, verbatim),
       close_tag(tag, options, level)]
   end
-  
+
   defp close_tag(tag, options, level) do
     [make_indent(options, level), "</", tag, ">\n"]
   end
@@ -90,7 +96,7 @@ defmodule Earmark.Transform do
 
   defp make_indent(%{indent: indent}, level) do
     Stream.cycle([" "])
-    |> Enum.take(level*indent) 
+    |> Enum.take(level*indent)
   end
 
   defp open_tag(tag, atts)

--- a/test/acceptance/html/render_specific/smarty_pants_test.exs
+++ b/test/acceptance/html/render_specific/smarty_pants_test.exs
@@ -18,6 +18,22 @@ defmodule Acceptance.Html.RenderSpecific.SmartyPantsTest do
       assert as_html(markdown) == {:ok, html, messages}
     end
 
+    test "ignores inline code" do
+      markdown = "`IO.puts \"no curly quotes\"`"
+      html     = "<p>\n<code class=\"inline\">IO.puts &quot;no curly quotes&quot;</code></p>\n"
+      messages = []
+
+      assert as_html(markdown) == {:ok, html, messages}
+    end
+
+    test "ignores pre code blocks" do
+      markdown = "```\nIO.puts \"no curly quotes\"\n```"
+      html     = "<pre><code>IO.puts &quot;no curly quotes&quot;</code></pre>\n"
+      messages = []
+
+      assert as_html(markdown) == {:ok, html, messages}
+    end
+
     test "two doubles" do
       markdown = "a \"double\" \"quote\""
       html     = "<p>\na “double” “quote”</p>\n"


### PR DESCRIPTION
Resolves #383 

It seems that the inline `<code>` elements aren't treated differently from other `@compact_tags`, so it misses that it should ignore smartypants syntax, like we do for `<pre>` tags

**One point I'm uncertain about is whether the output should be `"` or `&quot;`**. Ultimately I'm rendering this in HTML, so it renders correctly. The new tests currently assert that it's `&quot;`

For example,
using master:
![image](https://user-images.githubusercontent.com/643967/90173311-42814600-dd72-11ea-8825-198ef0d38910.png)


using this branch:
![image](https://user-images.githubusercontent.com/643967/90173366-59279d00-dd72-11ea-815c-a93c426e6f01.png)
