### PR TITLE
Treat <del> tag (used for strikethrough text) as a compact tag

### DIFF
--- a/lib/earmark.ex
+++ b/lib/earmark.ex
@@ -87,7 +87,7 @@ defmodule Earmark do
   #### Strike Through
 
       iex(1)> Earmark.as_html! ["~~hello~~"]
-      "<p>\\n  <del>\\nhello  </del>\\n</p>\\n"
+      "<p>\\n<del>hello</del></p>\\n"
 
   #### Syntax Highlighting
 
@@ -425,7 +425,7 @@ defmodule Earmark do
   @doc """
   `as_ast` is a compatibility function to call `EarmarkParser.as_ast`
 
-  It is deprecated and will be removed in 1.5! 
+  It is deprecated and will be removed in 1.5!
 
   Options are passes like to `as_html`, some do not have an effect though (e.g. `smartypants`) as formatting and escaping is not done
   for the AST.

--- a/lib/earmark/transform.ex
+++ b/lib/earmark/transform.ex
@@ -2,7 +2,7 @@ defmodule Earmark.Transform do
 
   import Earmark.Helpers, only: [replace: 3]
 
-  @compact_tags ~w[a code em strong]
+  @compact_tags ~w[a code em strong del]
 
   # https://www.w3.org/TR/2011/WD-html-markup-20110113/syntax.html#void-element
   @void_elements ~W(area base br col command embed hr img input keygen link meta param source track wbr)


### PR DESCRIPTION
## The issue

The `<del>` tag, which is used to render `~~strikethrough text~~`, is currently rendered using [this](https://github.com/pragdave/earmark/blob/7aa1157a239dd09774cf10d38bc0181c61fa55f9/lib/earmark/transform.ex#L69-L76) defintion of `_to_html/4`. Unfortunately, this results in a newline being output before the closing tag and so the strikethrough effect is longer than it should be.

## Before the fix

![image](https://user-images.githubusercontent.com/4295266/93246270-74783480-f784-11ea-85be-b5d9b6ed8f1f.png)

## After the fix

![image](https://user-images.githubusercontent.com/4295266/93246353-8fe33f80-f784-11ea-98c7-9823478bcda8.png)