### PR TITLE
 Add an optimized implementation for HTML escaping and part of smartypants

### DIFF
--- a/bench/simple_data_bench.exs
+++ b/bench/simple_data_bench.exs
@@ -499,7 +499,7 @@ defmodule Bench.SimpleDataBench do
   end
   
   bench "01 as_ast|>transform" do
-    {:ok, ast, []} = Earmark.as_ast(@readme_md)
+    {:ok, ast, []} = EarmarkParser.as_ast(@readme_md)
     Earmark.Transform.transform(ast)
   end
 end

--- a/lib/earmark/helpers.ex
+++ b/lib/earmark/helpers.ex
@@ -32,28 +32,6 @@ defmodule Earmark.Helpers do
   def replace(text, regex, replacement, options \\ []) do
     Regex.replace(regex, text, replacement, options)
   end
-
-  @doc """
-  Replace <, >, and quotes with the corresponding entities. If
-  `encode` is true, convert ampersands, too, otherwise only
-   convert non-entity ampersands.
-  """
-
-  @amp_rgx ~r{&(?!#?\w+;)}
-  @never_amp_rgx ~r{&(?!#x[0-9a-f]+;)}i
-  def escape(html, encode \\ false)
-
-  def escape(html, false), do: _escape(Regex.replace(@amp_rgx, html, "&amp;"))
-
-  def escape(html, _), do: _escape(Regex.replace(@never_amp_rgx, html, "&amp;"))
-
-  defp _escape(html) do
-    html
-    |> String.replace("<", "&lt;")
-    |> String.replace(">", "&gt;")
-    |> String.replace("\"", "&quot;")
-    |> String.replace("'", "&#39;")
-  end
 end
 
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
This patch replaces {String,Regex}.replace for HTML escaping and most
smartypants substitutions in favor of a faster custom implementation
that does only one pass using binary matches and outputs iodata.

The speedup in the benchmark is about 7-10% (29117.22 µs/op vs
27083.15 µs/op on a particular run). Note that it could be optimized
further by removing the remaining regexes, however the gained time
doesn't seem worth it for the added complexity.

This patch was written mostly as an experiment, feel free to reject
if you don't feel the added complexity is worth the speedup.