### PR TITLE
Add option to as_html for disabling HTML character escaping

### DIFF
--- a/lib/earmark.ex
+++ b/lib/earmark.ex
@@ -414,6 +414,9 @@ defmodule Earmark do
   * `compact_output`: boolean
 
     If set to true, no cosmetic newlines will be emitted by Earmark. False by default.
+
+  * `escape`: boolean
+    If set to false, HTML strings will not be escaped. True by default.
   """
   def as_html(lines, options \\ %Options{})
 

--- a/lib/earmark/options.ex
+++ b/lib/earmark/options.ex
@@ -13,6 +13,7 @@ defmodule Earmark.Options do
             footnotes: false,
             footnote_offset: 1,
             wikilinks: false,
+            escape: true,
 
             # additional prefies for class of code blocks
             code_class_prefix: nil,
@@ -49,7 +50,8 @@ defmodule Earmark.Options do
         pure_links: boolean,
         smartypants: boolean,
         wikilinks: boolean,
-        timeout: maybe(number)
+        timeout: maybe(number),
+        escape: boolean
   }
 
   @doc false

--- a/lib/earmark/transform.ex
+++ b/lib/earmark/transform.ex
@@ -92,7 +92,7 @@ defmodule Earmark.Transform do
 
   @dbl1_rgx ~r{(^|[-–—/\(\[\{"”“\s])'}
   @dbl2_rgx ~r{(^|[-–—/\(\[\{‘\s])\"}
-  defp escape(element, %{smartypants: true, escape: escape}) do
+  defp escape(element, %{smartypants: true} = options) do
     # Unfortunately these regexes still have to be left.
     # It doesn't seem possible to make escape_to_iodata
     # transform, for example, "--'" to "–‘" without
@@ -103,7 +103,8 @@ defmodule Earmark.Transform do
       |> replace(@dbl1_rgx, "\\1‘")
       |> replace(@dbl2_rgx, "\\1“")
 
-      escape_to_iodata(element, 0, element, [], true, escape, 0)
+    escape = Map.get(options, :escape, true)
+    escape_to_iodata(element, 0, element, [], true, escape, 0)
   end
 
   defp escape(element, %{escape: escape}) do
@@ -111,7 +112,7 @@ defmodule Earmark.Transform do
   end
 
   defp escape(element, _options) do
-      escape_to_iodata(element, 0, element, [], false, false, 0)
+      escape_to_iodata(element, 0, element, [], false, true, 0)
   end
 
   defp make_att(name_value_pair, tag)

--- a/lib/earmark/transform.ex
+++ b/lib/earmark/transform.ex
@@ -92,7 +92,7 @@ defmodule Earmark.Transform do
 
   @dbl1_rgx ~r{(^|[-–—/\(\[\{"”“\s])'}
   @dbl2_rgx ~r{(^|[-–—/\(\[\{‘\s])\"}
-  defp escape(element, %{smartypants: true}) do
+  defp escape(element, %{smartypants: true, escape: escape}) do
     # Unfortunately these regexes still have to be left.
     # It doesn't seem possible to make escape_to_iodata
     # transform, for example, "--'" to "–‘" without
@@ -103,11 +103,15 @@ defmodule Earmark.Transform do
       |> replace(@dbl1_rgx, "\\1‘")
       |> replace(@dbl2_rgx, "\\1“")
 
-      escape_to_iodata(element, 0, element, [], true, 0)
+      escape_to_iodata(element, 0, element, [], true, escape, 0)
+  end
+
+  defp escape(element, %{escape: escape}) do
+      escape_to_iodata(element, 0, element, [], false, escape, 0)
   end
 
   defp escape(element, _options) do
-      escape_to_iodata(element, 0, element, [], false, 0)
+      escape_to_iodata(element, 0, element, [], false, false, 0)
   end
 
   defp make_att(name_value_pair, tag)
@@ -136,8 +140,8 @@ defmodule Earmark.Transform do
   # https://github.com/elixir-plug/plug/blob/v1.11.0/lib/plug/html.ex
 
   # Do not escape HTML entities
-  defp escape_to_iodata("&#x" <> rest, skip, original, acc, smartypants, len) do
-    escape_to_iodata(rest, skip, original, acc, smartypants, len + 3)
+  defp escape_to_iodata("&#x" <> rest, skip, original, acc, smartypants, escape, len) do
+    escape_to_iodata(rest, skip, original, acc, smartypants, escape, len + 3)
   end
 
   escapes = [
@@ -162,36 +166,36 @@ defmodule Earmark.Transform do
     # Unlike HTML escape matches, smartypants matches may contain more than one character
     match_length = if is_binary(match), do: byte_size(match), else: 1
 
-    defp escape_to_iodata(<<unquote(match), rest::bits>>, skip, original, acc, true, 0) do
-      escape_to_iodata(rest, skip + unquote(match_length), original, [acc | unquote(insert)], true, 0)
+    defp escape_to_iodata(<<unquote(match), rest::bits>>, skip, original, acc, true, escape, 0) do
+      escape_to_iodata(rest, skip + unquote(match_length), original, [acc | unquote(insert)], true, escape, 0)
     end
 
-    defp escape_to_iodata(<<unquote(match), rest::bits>>, skip, original, acc, true, len) do
+    defp escape_to_iodata(<<unquote(match), rest::bits>>, skip, original, acc, true, escape, len) do
       part = binary_part(original, skip, len)
-      escape_to_iodata(rest, skip + len + unquote(match_length), original, [acc, part | unquote(insert)], true, 0)
+      escape_to_iodata(rest, skip + len + unquote(match_length), original, [acc, part | unquote(insert)], true, escape, 0)
     end
   end
 
   for {match, insert} <- escapes do
-    defp escape_to_iodata(<<unquote(match), rest::bits>>, skip, original, acc, smartypants, 0) do
-      escape_to_iodata(rest, skip + 1, original, [acc | unquote(insert)], smartypants, 0)
+    defp escape_to_iodata(<<unquote(match), rest::bits>>, skip, original, acc, smartypants, true, 0) do
+      escape_to_iodata(rest, skip + 1, original, [acc | unquote(insert)], smartypants, true, 0)
     end
 
-    defp escape_to_iodata(<<unquote(match), rest::bits>>, skip, original, acc, smartypants, len) do
+    defp escape_to_iodata(<<unquote(match), rest::bits>>, skip, original, acc, smartypants, true, len) do
       part = binary_part(original, skip, len)
-      escape_to_iodata(rest, skip + len + 1, original, [acc, part | unquote(insert)], smartypants, 0)
+      escape_to_iodata(rest, skip + len + 1, original, [acc, part | unquote(insert)], smartypants, true, 0)
     end
   end
 
-  defp escape_to_iodata(<<_char, rest::bits>>, skip, original, acc, smartypants, len) do
-    escape_to_iodata(rest, skip, original, acc, smartypants, len + 1)
+  defp escape_to_iodata(<<_char, rest::bits>>, skip, original, acc, smartypants, escape, len) do
+    escape_to_iodata(rest, skip, original, acc, smartypants, escape, len + 1)
   end
 
-  defp escape_to_iodata(<<>>, 0, original, _acc, _smartypants, _len) do
+  defp escape_to_iodata(<<>>, 0, original, _acc, _smartypants, _escape, _len) do
     original
   end
 
-  defp escape_to_iodata(<<>>, skip, original, acc, _smartypants, len) do
+  defp escape_to_iodata(<<>>, skip, original, acc, _smartypants, _escape, len) do
     [acc | binary_part(original, skip, len)]
   end
 end

--- a/test/acceptance/html/escape_test.exs
+++ b/test/acceptance/html/escape_test.exs
@@ -43,6 +43,14 @@ defmodule Acceptance.Html.EscapeTest do
 
       assert as_html(markdown, escape: false) == {:ok, html, messages}
     end
+
+    test "doesn't interfere with smartypants" do
+      markdown = "hello<br> 'world'"
+      html = "<p>\nhello<br> ‘world’</p>\n"
+      messages = []
+
+      assert as_html(markdown, escape: false, smartypants: true) == {:ok, html, messages}
+    end
   end
 
 end

--- a/test/acceptance/html/escape_test.exs
+++ b/test/acceptance/html/escape_test.exs
@@ -27,6 +27,24 @@ defmodule Acceptance.Html.EscapeTest do
     end
   end
 
+  describe "Escapes Disabled" do
+    test "line break tag (<br>)" do
+      markdown = "hello<br>world"
+      html = "<p>\nhello<br>world</p>\n"
+      messages = []
+
+      assert as_html(markdown, escape: false) == {:ok, html, messages}
+    end
+
+    test "semantic line break tag (<br/>)" do
+      markdown = "hello<br/>world"
+      html = "<p>\nhello<br/>world</p>\n"
+      messages = []
+
+      assert as_html(markdown, escape: false) == {:ok, html, messages}
+    end
+  end
+
 end
 
 # SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Adds an `escape` option, used by the HTML transform, to allow passing through of HTML tags without escaping.

Mostly useful when using table syntax, as there's no way to do newlines in a table cell without using `<br/>`