### PR TITLE
ensure a proplist as options is in use to retrieve filename

### DIFF
--- a/lib/earmark/message.ex
+++ b/lib/earmark/message.ex
@@ -37,7 +37,11 @@ defmodule Earmark.Message do
     messages
     |> Enum.each(&emit_message(file, &1))
   end
-  def emit_messages(messages, _) do
+  def emit_messages(messages, proplist) when is_list(proplist) do
+    messages
+    |> Enum.each(&emit_message(proplist[:file] || "<args>", &1))
+  end
+  def emit_messages(messages, options) do
     messages
     |> Enum.each(&emit_message("<args>", &1))
   end

--- a/lib/earmark/message.ex
+++ b/lib/earmark/message.ex
@@ -41,7 +41,7 @@ defmodule Earmark.Message do
     messages
     |> Enum.each(&emit_message(proplist[:file] || "<args>", &1))
   end
-  def emit_messages(messages, options) do
+  def emit_messages(messages, _options) do
     messages
     |> Enum.each(&emit_message("<args>", &1))
   end

--- a/test/acceptance/html/illegal_options_test.exs
+++ b/test/acceptance/html/illegal_options_test.exs
@@ -27,4 +27,12 @@ defmodule Test.Acceptance.Html.IllegalOptionsTest do
       end)
     assert error_messages == "<args>:0: warning: Unrecognized option oops: Earmark ignored\n"
   end 
+
+  test "with as_html! defining filename" do
+    error_messages =
+      capture_io(:stderr, fn ->
+        as_html!("hello", oops: Earmark, file: "test.md")
+      end)
+    assert error_messages == "test.md:0: warning: Unrecognized option oops: Earmark ignored\n"
+  end
 end


### PR DESCRIPTION
When we send options, they are formatted as `%Earmark.Options{}` and they are translated to `%EarmarkParser.Options{}` but, looks like they are back as Keyword list, so it's not possible to retrieve `file` from them. This PR fixes it.