### PR TITLE
[earmark] Unbreak compilation in Elixir 1.11

### DIFF
--- a/lib/earmark/transform.ex
+++ b/lib/earmark/transform.ex
@@ -131,11 +131,11 @@ defmodule Earmark.Transform do
       ...(8)> options = [
       ...(8)> registered_processors: [{"a", add_target}, {"p", &Earmark.AstTools.merge_atts_in_node(&1, class: "example")}]]
       ...(8)> markdown =
-      ...(8)> """
+      ...(8)> " " "
       ...(8)>   http://hello.x.com
       ...(8)>
       ...(8)>   [some](url)
-      ...(8)> """
+      ...(8)> " " "
       ...(8)> Earmark.as_html!(markdown, options)
       "<p class=\"example\">\n  <a href=\"http://hello.x.com\" target=\"_blank\">http://hello.x.com</a></p>\n<p class=\"example\">\n  <a href=\"url\">some</a></p>\n"
 


### PR DESCRIPTION
It seems like the Elixir 1.11 parser gets confused by this
```
> mix compile
Compiling 14 files (.ex)

== Compilation error in file lib/earmark/transform.ex ==
** (SyntaxError) lib/earmark/transform.ex:134:1: invalid location for heredoc terminator, please escape token or move it to its own line: """
    (elixir 1.11.4) lib/kernel/parallel_compiler.ex:314: anonymous fn/4 in Kernel.ParallelCompiler.spawn_workers/7
```