### PR TITLE
Allow structure modifications of child nodes during transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,8 @@ and the following code examples are therefore verified with `ExUnit` doctests.
   - [Earmark.Internal.from_file!/2](#earmarkinternalfrom_file2)
   - [Earmark.Internal.include/2](#earmarkinternalinclude2)
   - [Earmark.Transform](#earmarktransform)
-    - [Structure Conserving Transformers](#structure-conserving-transformers)
+    - [Transformers](#transformers)
     - [Postprocessors and Convenience Functions](#postprocessors-and-convenience-functions)
-    - [Structure Modifying Transformers](#structure-modifying-transformers)
 - [Contributing](#contributing)
 - [Author](#author)
 
@@ -217,20 +216,18 @@ And here is how it is used inside a template
 
 ### Earmark.Transform
 
-#### Structure Conserving Transformers
+#### Transformers
 
-For the convenience of processing the output of `EarmarkParser.as_ast` we expose two structure conserving
-mappers.
+For the convenience of processing the output of `EarmarkParser.as_ast` we expose two mappers.
 
 ##### `map_ast`
 
-takes a function that will be called for each node of the AST, where a leaf node is either a quadruple
+takes a function that will be called for each node of the AST, where a leaf node is either a quadruple of `{tag, attributes, children, meta}`
 like `{"code", [{"class", "inline"}], ["some code"], %{}}` or a text leaf like `"some code"`
 
-The result of the function call must be
+The result of the function call must be:
 
-- for nodes → a quadruple of which the third element will be ignored -- that might change in future,
-and will therefore classically be `nil`. The other elements replace the node
+- for nodes → a quadruple. The quadruple replace the node. If the children are not intended to be modified, that quadruple element may be `nil`.
 
 - for strings → strings
 
@@ -389,15 +386,6 @@ add some decoration
     ...(9)> Earmark.as_ast!(markdown, annotations: "%%") |> Earmark.Transform.map_ast_with(nil, add_smiley) |> Earmark.transform
     "<p>\nA joke  ὠ1</p>\n<p>\nCharming  ὠd</p>\n"
 ```
-
-#### Structure Modifying Transformers
-
-For structure modifications a tree traversal is needed and no clear pattern of how to assist this task with
-tools has emerged yet.
-
-
-
-
 
 ## Contributing
 

--- a/lib/earmark/transform.ex
+++ b/lib/earmark/transform.ex
@@ -482,9 +482,11 @@
     new = if ignore_strings, do: string, else: fun.(string)
     _walk_ast(rest, fun, ignore_strings, [new|result])
   end
-  defp _walk_ast([{_, _, content, _}=tuple|rest], fun, ignore_strings, result) do
-    {new_tag, new_atts, _, new_meta} = fun.(tuple)
-    _walk_ast([content|rest], fun, ignore_strings, [@pop, {new_tag, new_atts, [], new_meta}|result])
+  defp _walk_ast([{_tag, _atts, children, _meta}=tuple|rest], fun, ignore_strings, result) do
+    {new_tag, new_atts, new_children, new_meta} = fun.(tuple)
+    children = if is_nil(new_children), do: children, else: new_children
+
+    _walk_ast([children|rest], fun, ignore_strings, [@pop, {new_tag, new_atts, children, new_meta}|result])
   end
   defp _walk_ast([[h|t]|rest], fun, ignore_strings, result) do
     _walk_ast([h, t|rest], fun, ignore_strings, result)
@@ -503,9 +505,10 @@
       _walk_ast_with(rest, newv, fun, ignore_strings, [news|result])
     end
   end
-  defp _walk_ast_with([{_, _, content, _}=tuple|rest], value, fun, ignore_strings, result) do
-    {{new_tag, new_atts, _, new_meta}, new_value} = fun.(tuple, value)
-    _walk_ast_with([content|rest], new_value, fun, ignore_strings, [@pop, {new_tag, new_atts, [], new_meta}|result])
+  defp _walk_ast_with([{_tag, _atts, children, _meta}=tuple|rest], value, fun, ignore_strings, result) do
+    {{new_tag, new_atts, new_children, new_meta}, new_value} = fun.(tuple, value)
+    children = if is_nil(new_children), do: children, else: new_children
+    _walk_ast_with([children|rest], new_value, fun, ignore_strings, [@pop, {new_tag, new_atts, children, new_meta}|result])
   end
   defp _walk_ast_with([[h|t]|rest], value, fun, ignore_strings, result) do
     _walk_ast_with([h, t|rest], value, fun, ignore_strings, result)

--- a/test/transform_test.exs
+++ b/test/transform_test.exs
@@ -25,5 +25,23 @@ defmodule TransformTest do
     defp add_smiley(text, nil), do: {text, nil}
     defp add_smiley(text, ann), do: {text <> ann, nil}
   end
+
+  describe "structural modifications" do
+    test "transformations can modify their children" do
+      markdown = "## a caption"
+      {:ok, ast, []} = markdown |> EarmarkParser.as_ast()
+      rendered = ast
+                 |> map_ast(&add_children/1)
+                 |> Earmark.Transform.transform()
+
+      expected = "<h2>\n<a href=\"#a-caption\">¶</a>a caption</h2>\n"
+      assert rendered == expected
+    end
+
+    defp add_children({"h2", attrs, children, meta}) do
+      {"h2", attrs, [{"a", [{"href", "#a-caption"}], ["¶"], %{}}|children], meta}
+    end
+    defp add_children(tuple_or_string), do: tuple_or_string
+  end
 end
 #  SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Currently, it is not possible to transform nodes, or add some.
As was stated in the README there was no clear way defined on how to do that.

I wonder whether solving a sub-set of that problem might be easy enough for a start: modifying only children of nodes during the AST transform step.

This PR adds support for post_processors/transforms to modify their children. This allows, for example, to create a post processor
which maps captions (`h1`, `h2`, ...) to include anchor-links [as GitHub-flavored-MarkDown does](https://babelmark.github.io/?text=%23%23+heading+with+%5Ba+link%5D(to%3A%2F%2Fsome.url)).

<details>
<summary>Example of a post processor I intend to write</summary>

```elixir
defmodule MarkdownRenderer do
  def render_markdown(markdown) do
    {:ok, html_doc, _messages} = Earmark.as_html(markdown, postprocessor: &postprocessor/1) do
    html_doc
  end

  defp postprocessor({tag, attrs, child_nodes, meta}) when tag in ["h1", "h2", "h3", "h4", "h5"] do
    {
      tag,
      attrs,
      [anchor(child_nodes)|child_nodes],
      meta
    }
  end
  defp postprocessor(node), do: node

  @non_char ~r/[^a-z]+/
  defp anchor(child_nodes) do
    id = text_content(child_nodes)
         |> String.trim()
         |> String.replace(@non_char, "-", global: true)
    anchor_id = "user-content-#{id}"

    {"a", [{"id", anchor_id}, {"href", "##{anchor_id}"}, {"aria-hidden", "true"}, {"class", "anchor"}], [svg_node()], %{}}
  end

  defp text_content([]), do: ""
  defp text_content([node|rest]), do: "#{text_content(node)} #{text_content(rest)}"
  defp text_content(node) when is_binary(node), do: String.downcase(node)
  defp text_content({_tag, _attrs, children, _meta}) do
    children
    |> Enum.map(fn node -> text_content(node) end)
    |> Enum.join("-")
  end

  @link_path "M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"
  defp svg_node do
    {
      "svg",
      [{"class", "octicon octicon-link"}, {"viewBox", "0 0 16 16"}, {"version", "1.1"}, {"width", "16"}, {"height", "16"}, {"aria-hidden", "true"}],
      [
        {
          "path",
          [{"fill-rule", "evenodd"}, {"d", @link_path}],
          [],
          %{}
        }
      ],
      %{}
    }
  end
end
```
</details>

I assume this is debatable, as it does not allow all transformation that are imaginable.
But this solutions seems to work well within the existing code base and solves a bigger chunk of problems.

I'm happy to discuss my approach, as I might not have understood all details of the recursive `_walk_ast` function :)