### PR TITLE
Fix unused variable warnings

### DIFF
--- a/lib/earmark/options.ex
+++ b/lib/earmark/options.ex
@@ -198,15 +198,15 @@ defmodule Earmark.Options do
     options
   end
 
-  defp _check_options!(%__MODULE__{line: line, footnote_offset: fno}) when is_number(line) do
+  defp _check_options!(%__MODULE__{line: line}) when is_number(line) do
     {:error, [{:error, 0, "footnote_offset option must be numeric"}]}
   end
 
-  defp _check_options!(%__MODULE__{line: line, footnote_offset: fno}) when is_number(fno) do
+  defp _check_options!(%__MODULE__{footnote_offset: fno}) when is_number(fno) do
     {:error, [{:error, 0, "line option must be numeric"}]}
   end
 
-  defp _check_options!(%__MODULE__{line: line, footnote_offset: fno}) do
+  defp _check_options!(%__MODULE__{}) do
     {:error,
      [
        {:error, 0, "footnote_offset option must be numeric"},


### PR DESCRIPTION
Hello! I noticed a few warnings when upgrading to the latest version 👇 

I'll leave it up to you if you would rather keep the pattern matching but prefix the variables with `_`. I went for the other option.

Thank you for maintaining this lib! :)

```
Compiling 15 files (.ex)
warning: variable "fno" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/earmark/options.ex:201: Earmark.Options._check_options!/1

warning: variable "line" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/earmark/options.ex:205: Earmark.Options._check_options!/1

warning: variable "fno" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/earmark/options.ex:209: Earmark.Options._check_options!/1

warning: variable "line" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/earmark/options.ex:209: Earmark.Options._check_options!/1

Generated earmark app
```