### PR TITLE
Fix Restructure.walk_and_modify_ast failing on comment node

### DIFF
--- a/lib/earmark/restructure.ex
+++ b/lib/earmark/restructure.ex
@@ -81,7 +81,7 @@ defmodule Earmark.Restructure do
   defp walk_and_modify_ast_item(item, acc, process_item_fn, process_list_fn) do
     case process_item_fn.(item, acc) do
       {{type, attribs, items, annotations}, acc}
-      when is_binary(type) and is_list(attribs) and is_list(items) and is_map(annotations) ->
+      when (is_binary(type) or is_atom(type)) and is_list(attribs) and is_list(items) and is_map(annotations) ->
         {items, acc} = walk_and_modify_ast(items, acc, process_item_fn, process_list_fn)
         {{type, attribs, List.flatten(items), annotations}, acc}
       {item_or_items, acc} when is_binary(item_or_items) or is_list(item_or_items) ->

--- a/test/acceptance/restructure/walk_and_modify_ast_test.exs
+++ b/test/acceptance/restructure/walk_and_modify_ast_test.exs
@@ -123,5 +123,16 @@ defmodule Test.Restructure.WalkeAndModifyAstTest do
     {:ok, ast, []} = EarmarkParser.as_ast(markdown)
     Restructure.walk_and_modify_ast(ast, nil, italics_maker, comment_remover)
   end
+
+  test "comments are ok" do
+    markdown = """
+    <!--Comment-->
+
+    Hello world
+    """
+
+    {:ok, ast, []} = EarmarkParser.as_ast(markdown)
+    Restructure.walk_and_modify_ast(ast, nil, fn node, acc -> {node, acc} end)
+  end
 end
 #  SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
`Restructure.walk_and_modify_ast` crashes if AST includes a comment node since its types isn't binary, but an atom.