### PR TITLE
Avoid trailing slash on void elements.

### DIFF
--- a/bench/simple_data_bench.exs
+++ b/bench/simple_data_bench.exs
@@ -160,7 +160,7 @@ defmodule Bench.SimpleDataBench do
            Elixir  | awesome
 
   never is.
-   
+
 
 
   ### Adding HTML attributes with the IAL extension
@@ -260,22 +260,22 @@ defmodule Bench.SimpleDataBench do
     Thusly
 
           mypara
-          <hr />
+          <hr>
 
     Becomes
 
           <p>mypara</p>
-          <hr />
+          <hr>
 
     While
 
           mypara
-           <hr />
+           <hr>
 
     will be transformed into
 
           <p>mypara
-           <hr /></p>
+           <hr></p>
 
   ## Integration
 
@@ -355,7 +355,7 @@ defmodule Bench.SimpleDataBench do
   - description of the error
 
 
-  `options` can be an `%Earmark.Options{}` structure, or can be passed in as a `Keyword` argument (with legal keys for `%Earmark.Options` 
+  `options` can be an `%Earmark.Options{}` structure, or can be passed in as a `Keyword` argument (with legal keys for `%Earmark.Options`
 
   * `renderer`: ModuleName
 
@@ -400,7 +400,7 @@ defmodule Bench.SimpleDataBench do
   * `pure_links`: boolean
 
     Pure links of the form `~r{\bhttps?://\S+\b}` are rendered as links from now on.
-    However, by setting the `pure_links` option to `false` this can be disabled and pre 1.4 
+    However, by setting the `pure_links` option to `false` this can be disabled and pre 1.4
     behavior can be used.
 
   <!-- END inserted functiondoc Earmark.as_html/2 -->
@@ -413,7 +413,7 @@ defmodule Bench.SimpleDataBench do
         iex(9)> markdown = "My `code` is **best**"
         ...(9)> {:ok, ast, []} = Earmark.as_ast(markdown)
         ...(9)> ast
-        [{"p", [], ["My ", {"code", [{"class", "inline"}], ["code"]}, " is ", {"strong", [], ["best"]}]}] 
+        [{"p", [], ["My ", {"code", [{"class", "inline"}], ["code"]}, " is ", {"strong", [], ["best"]}]}]
 
   Options are passes like to `as_html`, some do not have an effect though (e.g. `smartypants`) as formatting and escaping is not done
   for the AST.
@@ -430,7 +430,7 @@ defmodule Bench.SimpleDataBench do
   We also do return a list for a single node
 
 
-        Floki.parse("<!-- comment -->")           
+        Floki.parse("<!-- comment -->")
         {:comment, " comment "}
 
         Earmark.as_ast("<!-- comment -->")
@@ -497,7 +497,7 @@ defmodule Bench.SimpleDataBench do
   bench "00 as_html" do
     Earmark.as_html(@readme_md)
   end
-  
+
   bench "01 as_ast|>transform" do
     {:ok, ast, []} = EarmarkParser.as_ast(@readme_md)
     Earmark.Transform.transform(ast)

--- a/lib/earmark.ex
+++ b/lib/earmark.ex
@@ -1,8 +1,10 @@
 defmodule Earmark do
-  if Version.compare(System.version, "1.12.0") == :lt do
-    IO.puts(:stderr, "DEPRECATION WARNING: versions < 1.12.0 of Elixir are not tested anymore and will not be supported in Earmark v1.5")
+  if Version.compare(System.version(), "1.12.0") == :lt do
+    IO.puts(
+      :stderr,
+      "DEPRECATION WARNING: versions < 1.12.0 of Elixir are not tested anymore and will not be supported in Earmark v1.5"
+    )
   end
-
 
   @type ast_meta :: map()
   @type ast_tag :: binary()
@@ -103,16 +105,16 @@ defmodule Earmark do
 
   If set HTML will be properly escaped
 
-        iex(3)> markdown = "Hello<br />World"
+        iex(3)> markdown = "Hello<br>World"
         ...(3)> Earmark.as_html!(markdown)
-        "<p>\\nHello&lt;br /&gt;World</p>\\n"
+        "<p>\\nHello&lt;br&gt;World</p>\\n"
 
   However disabling `escape:` gives you maximum control of the created document, which in some
   cases (e.g. inside tables) might even be necessary
 
-        iex(4)> markdown = "Hello<br />World"
+        iex(4)> markdown = "Hello<br>World"
         ...(4)> Earmark.as_html!(markdown, escape: false)
-        "<p>\\nHello<br />World</p>\\n"
+        "<p>\\nHello<br>World</p>\\n"
 
   #### `inner_html:` defaulting to `false`
 
@@ -127,9 +129,9 @@ defmodule Earmark do
   By means of the `inner_html` option the disturbing paragraph can be removed from `as_html!`'s
   output
 
-        iex(5)> markdown = "Hello<br />World"
+        iex(5)> markdown = "Hello<br>World"
         ...(5)> Earmark.as_html!(markdown, escape: false, inner_html: true)
-        "Hello<br />World\\n"
+        "Hello<br>World\\n"
 
   **N.B.** that this applies only to top level paragraphs, as can be seen here
 
@@ -262,7 +264,6 @@ defmodule Earmark do
       do: to_string(version)
   end
 
-
   defp _as_ast(lines, options)
 
   defp _as_ast(lines, %Options{} = options) do
@@ -273,4 +274,5 @@ defmodule Earmark do
     Proxy.as_ast(lines, options)
   end
 end
+
 # SPDX-License-Identifier: Apache-2.0

--- a/lib/earmark/cli.ex
+++ b/lib/earmark/cli.ex
@@ -1,6 +1,4 @@
 defmodule Earmark.Cli do
-
-
   @moduledoc """
   The Earmark CLI
 
@@ -22,12 +20,12 @@ defmodule Earmark.Cli do
   or raise an error otherwise
 
       iex(0)> run!(["test/fixtures/short1.md"])
-      "<h1>\nHeadline1</h1>\n<hr class=\"thin\" />\n<h2>\nHeadline2</h2>\n"
+      "<h1>\nHeadline1</h1>\n<hr class=\"thin\">\n<h2>\nHeadline2</h2>\n"
   """
   def run!(argv) do
     case Earmark.Cli.Implementation.run(argv) do
       {:stdio, output} -> output
-      {_, error}       -> raise Earmark.Error, error
+      {_, error} -> raise Earmark.Error, error
     end
   end
 
@@ -36,4 +34,5 @@ defmodule Earmark.Cli do
     if device == :stderr, do: exit(1)
   end
 end
+
 #  SPDX-License-Identifier: Apache-2.0

--- a/test/acceptance/html/block_quotes_test.exs
+++ b/test/acceptance/html/block_quotes_test.exs
@@ -4,13 +4,13 @@ defmodule Acceptance.Html.BlockQuotesTest do
   describe "with breaks: true" do
     test "acceptance test 490 with breaks" do
       markdown = "> bar\nbaz\n> foo\n"
-      html     = "<blockquote>\n  <p>\nbar    <br />\nbaz    <br />\nfoo  </p>\n</blockquote>\n"
+      html = "<blockquote>\n  <p>\nbar    <br>\nbaz    <br>\nfoo  </p>\n</blockquote>\n"
       assert Earmark.as_html!(markdown, breaks: true) == html
     end
 
     test "acceptance test 582 with breaks" do
       markdown = "* x\n  a\n| A | B |"
-      html     = "<ul>\n  <li>\nx    <br />\na    <br />\n| A | B |  </li>\n</ul>\n"
+      html = "<ul>\n  <li>\nx    <br>\na    <br>\n| A | B |  </li>\n</ul>\n"
       assert Earmark.as_html!(markdown, breaks: true) == html
     end
   end
@@ -18,7 +18,7 @@ defmodule Acceptance.Html.BlockQuotesTest do
   describe "with breaks: false" do
     test "quote my block" do
       markdown = "> Foo"
-      html     = "<blockquote>\n  <p>\nFoo  </p>\n</blockquote>\n"
+      html = "<blockquote>\n  <p>\nFoo  </p>\n</blockquote>\n"
       messages = []
 
       assert Earmark.as_html(markdown) == {:ok, html, messages}
@@ -26,7 +26,10 @@ defmodule Acceptance.Html.BlockQuotesTest do
 
     test "lists in blockquotes? Coming up Sir" do
       markdown = "> - foo\n- bar\n"
-      html     = "<blockquote>\n  <ul>\n    <li>\nfoo    </li>\n  </ul>\n</blockquote>\n<ul>\n  <li>\nbar  </li>\n</ul>\n"
+
+      html =
+        "<blockquote>\n  <ul>\n    <li>\nfoo    </li>\n  </ul>\n</blockquote>\n<ul>\n  <li>\nbar  </li>\n</ul>\n"
+
       messages = []
 
       assert Earmark.as_html(markdown) == {:ok, html, messages}
@@ -34,12 +37,14 @@ defmodule Acceptance.Html.BlockQuotesTest do
 
     test "indented case" do
       markdown = " > - foo\n- bar\n"
-      html     = "<blockquote>\n  <ul>\n    <li>\nfoo    </li>\n  </ul>\n</blockquote>\n<ul>\n  <li>\nbar  </li>\n</ul>\n"
+
+      html =
+        "<blockquote>\n  <ul>\n    <li>\nfoo    </li>\n  </ul>\n</blockquote>\n<ul>\n  <li>\nbar  </li>\n</ul>\n"
+
       messages = []
 
       assert Earmark.as_html(markdown) == {:ok, html, messages}
     end
-
   end
 end
 

--- a/test/acceptance/html/escape_test.exs
+++ b/test/acceptance/html/escape_test.exs
@@ -4,7 +4,7 @@ defmodule Acceptance.Html.EscapeTest do
   describe "Escapes" do
     test "dizzy?" do
       markdown = "\\\\!\\\\\""
-      html     = "<p>\n\\!\\”</p>\n"
+      html = "<p>\n\\!\\”</p>\n"
       messages = []
 
       assert as_html(markdown, smartypants: true) == {:ok, html, messages}
@@ -12,7 +12,7 @@ defmodule Acceptance.Html.EscapeTest do
 
     test "dizzy and not smart :O" do
       markdown = "\\\\!\\\\\""
-      html     = "<p>\n\\!\\&quot;</p>\n"
+      html = "<p>\n\\!\\&quot;</p>\n"
       messages = []
 
       assert as_html(markdown, smartypants: false) == {:ok, html, messages}
@@ -20,7 +20,7 @@ defmodule Acceptance.Html.EscapeTest do
 
     test "less obviously - escpe the escapes" do
       markdown = "\\\\` code`"
-      html     = "<p>\n\\<code class=\"inline\">code</code></p>\n"
+      html = "<p>\n\\<code class=\"inline\">code</code></p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -44,9 +44,9 @@ defmodule Acceptance.Html.EscapeTest do
       assert as_html(markdown, escape: false, smartypants: false) == {:ok, html, messages}
     end
 
-    test "semantic line break tag (<br />)" do
-      markdown = "hello<br />world"
-      html = "<p>\nhello<br />world</p>\n"
+    test "semantic line break tag (<br>)" do
+      markdown = "hello<br>world"
+      html = "<p>\nhello<br>world</p>\n"
       messages = []
 
       assert as_html(markdown, escape: false) == {:ok, html, messages}
@@ -60,7 +60,6 @@ defmodule Acceptance.Html.EscapeTest do
       assert as_html(markdown, escape: false, smartypants: true) == {:ok, html, messages}
     end
   end
-
 end
 
 # SPDX-License-Identifier: Apache-2.0

--- a/test/acceptance/html/footnotes_test.exs
+++ b/test/acceptance/html/footnotes_test.exs
@@ -4,11 +4,12 @@ defmodule Acceptance.Html.FootnotesTest do
   describe "Footnotes" do
     test "without errors" do
       markdown = "foo[^1] again\n\n[^1]: bar baz"
+
       html = """
       <p>
       foo<a href=\"#fn:1\" id=\"fnref:1\" class=\"footnote\" title=\"see footnote\">1</a> again</p>
       <div class=\"footnotes\">
-        <hr />
+        <hr>
         <ol>
           <li id=\"fn:1\">
       <a class=\"reversefootnote\" href=\"#fnref:1\" title=\"return to article\">&#x21A9;</a>      <p>
@@ -17,12 +18,12 @@ defmodule Acceptance.Html.FootnotesTest do
         </ol>
       </div>
       """
+
       messages = []
 
       assert as_html(markdown, footnotes: true) == {:ok, html, messages}
     end
   end
-
 end
 
 # SPDX-License-Identifier: Apache-2.0

--- a/test/acceptance/html/hard_line_breaks_test.exs
+++ b/test/acceptance/html/hard_line_breaks_test.exs
@@ -1,26 +1,25 @@
 defmodule Acceptance.Html.HardLineBreaksTest do
   use Support.AcceptanceTestCase
 
-  describe "gfm" do 
-    test "hard line breaks are enabled" do 
+  describe "gfm" do
+    test "hard line breaks are enabled" do
       markdown = "line 1\nline 2\\\nline 3"
-      html     = "<p>\nline 1\nline 2  <br />\nline 3</p>\n"
+      html = "<p>\nline 1\nline 2  <br>\nline 3</p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
     end
   end
 
-  describe "no gfm" do 
-    test "hard line breaks are not enabled" do 
+  describe "no gfm" do
+    test "hard line breaks are not enabled" do
       markdown = "line 1\nline 2\\\nline 3"
-      html     = "<p>\nline 1\nline 2\\\nline 3</p>\n"
+      html = "<p>\nline 1\nline 2\\\nline 3</p>\n"
       messages = []
 
       assert as_html(markdown, gfm: false) == {:ok, html, messages}
     end
   end
-
 end
 
 # SPDX-License-Identifier: Apache-2.0

--- a/test/acceptance/html/horizontal_rules_test.exs
+++ b/test/acceptance/html/horizontal_rules_test.exs
@@ -1,10 +1,10 @@
 defmodule Acceptance.Html.HorizontalRulesTest do
   use Support.AcceptanceTestCase
-  describe "Horizontal rules" do
 
+  describe "Horizontal rules" do
     test "thick, thin & medium" do
       markdown = "***\n---\n___\n"
-      html     = "<hr class=\"thick\" />\n<hr class=\"thin\" />\n<hr class=\"medium\" />\n"
+      html = "<hr class=\"thick\">\n<hr class=\"thin\">\n<hr class=\"medium\">\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -12,7 +12,7 @@ defmodule Acceptance.Html.HorizontalRulesTest do
 
     test "not in code, second line" do
       markdown = "Foo\n    ***\n"
-      html     = "<p>\nFoo</p>\n<pre><code>***</code></pre>\n"
+      html = "<p>\nFoo</p>\n<pre><code>***</code></pre>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -20,24 +20,24 @@ defmodule Acceptance.Html.HorizontalRulesTest do
 
     test "medium, long" do
       markdown = "_____________________________________\n"
-      html     = "<hr class=\"medium\" />\n"
+      html = "<hr class=\"medium\">\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
     end
-
   end
 
-  describe "Horizontal Rules and IAL" do 
+  describe "Horizontal Rules and IAL" do
     test "add a class and an id" do
       markdown = "***\n{: .custom}\n---\n{: .klass #id42}\n___\n"
-      html     = "<hr class=\"custom thick\" />\n<hr class=\"klass thin\" id=\"id42\" />\n<hr class=\"medium\" />\n"
+
+      html =
+        "<hr class=\"custom thick\">\n<hr class=\"klass thin\" id=\"id42\">\n<hr class=\"medium\">\n"
+
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
-
     end
-    
   end
 end
 

--- a/test/acceptance/html/html_test.exs
+++ b/test/acceptance/html/html_test.exs
@@ -3,8 +3,12 @@ defmodule Acceptance.Html.HtmlBlocksTest do
 
   describe "HTML blocks" do
     test "tables are just tables again (or was that mountains?)" do
-      markdown = "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n"
-      html     = "<table>\n    <tr>\n    <td>\n           hi\n    </td>\n  </tr></table>\n<p>\nokay.</p>\n"
+      markdown =
+        "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n"
+
+      html =
+        "<table>\n    <tr>\n    <td>\n           hi\n    </td>\n  </tr></table>\n<p>\nokay.</p>\n"
+
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -13,8 +17,12 @@ defmodule Acceptance.Html.HtmlBlocksTest do
 
   describe "HTML void elements" do
     test "area" do
-      markdown = "<area shape=\"rect\" coords=\"0,0,1,1\" href=\"xxx\" alt=\"yyy\">\n**emphasized** text"
-      html     =  "<area shape=\"rect\" coords=\"0,0,1,1\" href=\"xxx\" alt=\"yyy\" />\n<p>\n<strong>emphasized</strong> text</p>\n"
+      markdown =
+        "<area shape=\"rect\" coords=\"0,0,1,1\" href=\"xxx\" alt=\"yyy\">\n**emphasized** text"
+
+      html =
+        "<area shape=\"rect\" coords=\"0,0,1,1\" href=\"xxx\" alt=\"yyy\">\n<p>\n<strong>emphasized</strong> text</p>\n"
+
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -24,7 +32,7 @@ defmodule Acceptance.Html.HtmlBlocksTest do
   describe "HTML Oneline tags" do
     test "without compact output" do
       markdown = "<div class=\"lead\">**Some** text here.</div>"
-      html     = "<div class=\"lead\">\n  **Some** text here.</div>\n"
+      html = "<div class=\"lead\">\n  **Some** text here.</div>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -32,7 +40,7 @@ defmodule Acceptance.Html.HtmlBlocksTest do
 
     test "with compact output" do
       markdown = "<div class=\"lead\">**Some** text here.</div>"
-      html     = "<div class=\"lead\">**Some** text here.</div>"
+      html = "<div class=\"lead\">**Some** text here.</div>"
       messages = []
 
       assert as_html(markdown, compact_output: true) == {:ok, html, messages}
@@ -40,12 +48,11 @@ defmodule Acceptance.Html.HtmlBlocksTest do
   end
 
   describe "HTML and paragraphs" do
-
     # Related to [#326](https://github.com/pragdave/earmark/issues/326)
     @tag :wip
     test "void elements close para but only at BOL" do
       markdown = "alpha\n <hr />beta"
-      html     = "<p>alpha\n <hr />beta</p>\n"
+      html = "<p>alpha\n <hr />beta</p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -54,11 +61,15 @@ defmodule Acceptance.Html.HtmlBlocksTest do
     @tag :wip
     test "self closing block elements close para, atts and spaces do not matter" do
       markdown = "alpha\n<div class=\"first\"   />beta\ngamma"
-      html     = gen([
-        {:p, "alpha"},
-        {:div, [class: "first"], [""]},
-        "beta",
-        {:p, "gamma"}])
+
+      html =
+        gen([
+          {:p, "alpha"},
+          {:div, [class: "first"], [""]},
+          "beta",
+          {:p, "gamma"}
+        ])
+
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -68,7 +79,7 @@ defmodule Acceptance.Html.HtmlBlocksTest do
     @tag :wip
     test "self closing block elements close para but only at BOL, atts do not matter" do
       markdown = "alpha\ngamma<div class=\"fourty two\"/>beta"
-      html     = "<p>alpha\ngamma<div class=\"fourty two\"/>beta</p>\n"
+      html = "<p>alpha\ngamma<div class=\"fourty two\"/>beta</p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -78,13 +89,12 @@ defmodule Acceptance.Html.HtmlBlocksTest do
     @tag :wip
     test "block elements close para" do
       markdown = "alpha\n<div></div>beta"
-      html     = "<p>alpha</p>\n<div></div>beta"
+      html = "<p>alpha</p>\n<div></div>beta"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
     end
   end
-
 end
 
 # SPDX-License-Identifier: Apache-2.0

--- a/test/acceptance/html/line_breaks_test.exs
+++ b/test/acceptance/html/line_breaks_test.exs
@@ -4,7 +4,7 @@ defmodule Acceptance.Html.LineBreaksTest do
   describe "Forced Line Breaks" do
     test "with two spaces" do
       markdown = "The  \nquick"
-      html     = "<p>\nThe  <br />\nquick</p>\n"
+      html = "<p>\nThe  <br>\nquick</p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -14,14 +14,15 @@ defmodule Acceptance.Html.LineBreaksTest do
   describe "No Forced Line Breaks" do
     test "or inside the line" do
       markdown = "The  quick\nbrown"
-      html     = "<p>\nThe  quick\nbrown</p>\n"
+      html = "<p>\nThe  quick\nbrown</p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
     end
+
     test "or in code blocks" do
       markdown = "```\nThe  \nquick\n```"
-      html     = "<pre><code>The  \nquick</code></pre>\n"
+      html = "<pre><code>The  \nquick</code></pre>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}

--- a/test/acceptance/html/links_images/img_test.exs
+++ b/test/acceptance/html/links_images/img_test.exs
@@ -1,13 +1,12 @@
 defmodule Acceptance.Html.LinkImages.ImgTest do
   use ExUnit.Case, async: true
 
-  import Support.GenHtml
   import Support.Helpers, only: [as_html: 1]
 
   describe "Image reference definitions" do
     test "img with title" do
       markdown = "[foo]: /url \"title\"\n\n![foo]\n"
-      html     = img(src: "/url", alt: "foo", title: "title")
+      html = "<p>\n  <img src=\"/url\" alt=\"foo\" title=\"title\">\n</p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -17,16 +16,15 @@ defmodule Acceptance.Html.LinkImages.ImgTest do
   describe "Link and Image imbrication" do
     test "as with this img" do
       markdown = "![[text](inner)](outer)"
-      html     = img(src: "outer", alt: "[text](inner)")
+      html = "<p>\n  <img src=\"outer\" alt=\"[text](inner)\">\n</p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
     end
 
-
     test "a lonely moon" do
       markdown = "![moon](moon.jpg)\n"
-      html     = img(src: "moon.jpg", alt: "moon")
+      html = "<p>\n  <img src=\"moon.jpg\" alt=\"moon\">\n</p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -36,28 +34,27 @@ defmodule Acceptance.Html.LinkImages.ImgTest do
   describe "Images" do
     test "title" do
       markdown = "![foo](/url \"title\")\n"
-      html     = img(src: "/url", alt: "foo", title: "title")
+      html = "<p>\n  <img src=\"/url\" alt=\"foo\" title=\"title\">\n</p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
     end
 
     test "parens: images" do
-      result = Earmark.as_html! "(![text](src))"
-      html     = "<p>\n(  <img src=\"src\" alt=\"text\" />\n)</p>\n"
+      result = Earmark.as_html!("(![text](src))")
+      html = "<p>\n(  <img src=\"src\" alt=\"text\">\n)</p>\n"
 
       assert result == html
     end
 
     test "as does everything else" do
       markdown = "![f[]oo](/url \"ti() tle\")\n"
-      html     = img(src: "/url", alt: "f[]oo", title: "ti() tle")
+      html = "<p>\n  <img src=\"/url\" alt=\"f[]oo\" title=\"ti() tle\">\n</p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
     end
   end
-
 end
 
 # SPDX-License-Identifier: Apache-2.0

--- a/test/acceptance/html/links_images/titles_test.exs
+++ b/test/acceptance/html/links_images/titles_test.exs
@@ -4,8 +4,11 @@ defmodule Acceptance.Html.LinksImages.TitlesTest do
   describe "Links with titles" do
     test "two titled links" do
       mark_tmp = "[link](/uri \"title\")"
-      markdown = "#{ mark_tmp } #{ mark_tmp }\n"
-      html     = "<p>\n<a href=\"/uri\" title=\"title\">link</a> <a href=\"/uri\" title=\"title\">link</a></p>\n"
+      markdown = "#{mark_tmp} #{mark_tmp}\n"
+
+      html =
+        "<p>\n<a href=\"/uri\" title=\"title\">link</a> <a href=\"/uri\" title=\"title\">link</a></p>\n"
+
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -15,11 +18,13 @@ defmodule Acceptance.Html.LinksImages.TitlesTest do
   describe "Images, and links with titles" do
     test "two titled images, different quotes" do
       markdown = ~s{![a](a 't') ![b](b "u")}
-      html     = "<p>\n  <img src=\"a\" alt=\"a\" title=\"t\" />\n   <img src=\"b\" alt=\"b\" title=\"u\" />\n</p>\n"
+
+      html =
+        "<p>\n  <img src=\"a\" alt=\"a\" title=\"t\">\n   <img src=\"b\" alt=\"b\" title=\"u\">\n</p>\n"
+
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
     end
   end
-
 end

--- a/test/acceptance/html/reflink_test.exs
+++ b/test/acceptance/html/reflink_test.exs
@@ -4,7 +4,7 @@ defmodule Acceptance.Html.ReflinkTest do
   describe "undefined reflinks" do
     test "simple case" do
       markdown = "[text] [reference]\n[reference1]: some_url"
-      html     = "<p>\n[text] [reference]</p>\n"
+      html = "<p>\n[text] [reference]</p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -14,7 +14,7 @@ defmodule Acceptance.Html.ReflinkTest do
   describe "defined reflinks" do
     test "simple case" do
       markdown = "[text] [reference]\n[reference]: some_url"
-      html     = "<p>\n<a href=\"some_url\" title=\"\">text</a></p>\n"
+      html = "<p>\n<a href=\"some_url\" title=\"\">text</a></p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}
@@ -22,7 +22,7 @@ defmodule Acceptance.Html.ReflinkTest do
 
     test "image with title" do
       markdown = "![text] [reference]\n[reference]: some_url 'a title'"
-      html     = para({:img, [src: "some_url", alt: "text", title: "a title"], nil})
+      html = "<p>\n  <img src=\"some_url\" alt=\"text\" title=\"a title\">\n</p>\n"
       messages = []
 
       assert as_html(markdown) == {:ok, html, messages}

--- a/test/fixtures/medium.md
+++ b/test/fixtures/medium.md
@@ -53,9 +53,9 @@ The implication of the "one or more consecutive lines of text" rule is
 that Markdown supports "hard-wrapped" text paragraphs. This differs
 significantly from most other text-to-HTML formatters (including Movable
 Type's "Convert Line Breaks" option) which translate every line break
-character in a paragraph into a `<br />` tag.
+character in a paragraph into a `<br>` tag.
 
-When you *do* want to insert a `<br />` break tag using Markdown, you
+When you *do* want to insert a `<br>` break tag using Markdown, you
 end a line with two or more spaces, then type return.
 
 ### Headers

--- a/test/support/acceptance_test_case.ex
+++ b/test/support/acceptance_test_case.ex
@@ -1,5 +1,4 @@
 defmodule Support.AcceptanceTestCase do
-
   defmacro __using__(_options) do
     quote do
       use ExUnit.Case, async: true
@@ -8,6 +7,6 @@ defmodule Support.AcceptanceTestCase do
       import Support.GenHtml
     end
   end
-
 end
+
 # SPDX-License-Identifier: Apache-2.0

--- a/test/support/html1_helpers.ex
+++ b/test/support/html1_helpers.ex
@@ -1,30 +1,33 @@
 defmodule Support.Html1Helpers do
-
   def to_html1(markdown, options \\ []) do
     {status, ast, messages} = EarmarkParser.as_ast(markdown, options)
+
     if System.get_env("DEBUG") do
       IO.inspect({:ast, ast})
     end
+
     {status, Earmark.Transform.transform(ast, options), messages}
   end
 
   def to_html2(markdown, options \\ []) do
     {:ok, ast, []} = EarmarkParser.as_ast(markdown, options)
+
     if System.get_env("DEBUG") do
       IO.inspect({:ast, ast})
     end
+
     ast
     |> Earmark.Transform.transform(options)
     |> parse_trimmed()
   end
 
-
   def construct(constructions, indent \\ 2) do
-    result =
-    _construct(constructions, 0, [], indent) |> IO.iodata_to_binary
+    result = _construct(constructions, 0, [], indent) |> IO.iodata_to_binary()
+
     if System.get_env("DEBUG") do
       IO.inspect({:constructed, result})
     end
+
     result
   end
 
@@ -33,17 +36,21 @@ defmodule Support.Html1Helpers do
   end
 
   def fcode(code, lang)
+
   def fcode(code, lang) do
     ~s{<pre><code class="#{lang}">#{code}</code></pre>\n}
   end
 
   def para(constructions, indent \\ 2)
-  def para(construction, indent) when is_binary(construction), do: construct([:p, construction], indent)
-  def para(constructions, indent), do: construct([:p|constructions], indent)
+
+  def para(construction, indent) when is_binary(construction),
+    do: construct([:p, construction], indent)
+
+  def para(constructions, indent), do: construct([:p | constructions], indent)
 
   def parse_trimmed(html) do
     html
-    |> Floki.parse_fragment!
+    |> Floki.parse_fragment!()
     |> Traverse.map!(fn x when is_binary(x) -> String.trim(x) end)
   end
 
@@ -57,69 +64,128 @@ defmodule Support.Html1Helpers do
 
   defp _construct(constructions, indent, open, iby)
   defp _construct([], _indent, [], _iby), do: []
-  defp _construct([], indent, [open|rest], iby) do
-    [_indent(indent - iby), "</", to_string(open), ">\n", _construct([], indent - iby, rest, iby) ]
+
+  defp _construct([], indent, [open | rest], iby) do
+    [_indent(indent - iby), "</", to_string(open), ">\n", _construct([], indent - iby, rest, iby)]
   end
-  defp _construct([:POP|rest], indent, [tag|rest1], iby) do
-    [_indent(indent-iby), "</", to_string(tag), ">\n", _construct(rest, indent - iby, rest1, iby)]
+
+  defp _construct([:POP | rest], indent, [tag | rest1], iby) do
+    [
+      _indent(indent - iby),
+      "</",
+      to_string(tag),
+      ">\n",
+      _construct(rest, indent - iby, rest1, iby)
+    ]
   end
+
   defp _construct(head, indent, open, iby) when is_tuple(head) do
     _construct([head], indent, open, iby)
   end
+
   defp _construct([:br | rest], indent, open, iby) do
-    _void_tag("<br />\n", rest, indent, open, iby)
+    _void_tag("<br>\n", rest, indent, open, iby)
   end
+
   defp _construct([:hr | rest], indent, open, iby) do
-    _void_tag("<hr />\n", rest, indent, open, iby)
+    _void_tag("<hr>\n", rest, indent, open, iby)
   end
+
   defp _construct([:wbr | rest], indent, open, iby) do
-    _void_tag("<wbr />\n", rest, indent, open, iby)
+    _void_tag("<wbr>\n", rest, indent, open, iby)
   end
+
   defp _construct([{:area, atts} | rest], indent, open, iby) do
     _void_tag_with_atts("<area ", atts, rest, indent, open, iby)
   end
+
   defp _construct([{:hr, atts} | rest], indent, open, iby) do
     _void_tag_with_atts("<hr ", atts, rest, indent, open, iby)
   end
+
   defp _construct([{:img, atts} | rest], indent, open, iby) do
     _void_tag_with_atts("<img ", atts, rest, indent, open, iby)
   end
+
   defp _construct([tag | rest], indent, open, iby) when is_atom(tag) do
-    [_indent(indent), "<", to_string(tag), ">", "\n", _construct(rest, indent + iby, [tag | open], iby)]
+    [
+      _indent(indent),
+      "<",
+      to_string(tag),
+      ">",
+      "\n",
+      _construct(rest, indent + iby, [tag | open], iby)
+    ]
   end
-  defp _construct([content|rest], indent, open, iby) when is_binary(content) do
+
+  defp _construct([content | rest], indent, open, iby) when is_binary(content) do
     [_indent(indent), content, "\n", _construct(rest, indent, open, iby)]
   end
-  defp _construct([{tag, content}|rest], indent, open, iby) when is_tuple(content), do: _construct([{tag, nil, content}|rest], indent, open, iby)
-  defp _construct([{tag, content}|rest], indent, open, iby) when is_list(content), do: _construct([{tag, nil, content}|rest], indent, open, iby)
-  defp _construct([{tag, atts}|rest], indent, open, iby) do
-    [_indent(indent), "<", to_string(tag), " ", atts, ">", "\n", _construct(rest, indent + iby, [tag | open], iby)]
+
+  defp _construct([{tag, content} | rest], indent, open, iby) when is_tuple(content),
+    do: _construct([{tag, nil, content} | rest], indent, open, iby)
+
+  defp _construct([{tag, content} | rest], indent, open, iby) when is_list(content),
+    do: _construct([{tag, nil, content} | rest], indent, open, iby)
+
+  defp _construct([{tag, atts} | rest], indent, open, iby) do
+    [
+      _indent(indent),
+      "<",
+      to_string(tag),
+      " ",
+      atts,
+      ">",
+      "\n",
+      _construct(rest, indent + iby, [tag | open], iby)
+    ]
   end
-  defp _construct([{tag, atts, content}|rest], indent, open, iby) when is_binary(content) do
-    _construct([{tag, atts, [content]}|rest], indent, open, iby)
+
+  defp _construct([{tag, atts, content} | rest], indent, open, iby) when is_binary(content) do
+    _construct([{tag, atts, [content]} | rest], indent, open, iby)
   end
-  defp _construct([{tag, nil, content}|rest], indent, open, iby) do
-    [_indent(indent), "<", to_string(tag), ">",
-     "\n",
-     _construct(content, indent + iby, [], iby),
-     _indent(indent), "</", to_string(tag), ">\n",
-     _construct(rest, indent, open, iby)]
+
+  defp _construct([{tag, nil, content} | rest], indent, open, iby) do
+    [
+      _indent(indent),
+      "<",
+      to_string(tag),
+      ">",
+      "\n",
+      _construct(content, indent + iby, [], iby),
+      _indent(indent),
+      "</",
+      to_string(tag),
+      ">\n",
+      _construct(rest, indent, open, iby)
+    ]
   end
-  defp _construct([{tag, atts, content}|rest], indent, open, iby) do
-    [_indent(indent), "<", to_string(tag), " ", atts, ">",
-     "\n",
-     _construct(content, indent + iby, [], iby),
-     _indent(indent), "</", to_string(tag), ">\n",
-     _construct(rest, indent, open, iby)]
+
+  defp _construct([{tag, atts, content} | rest], indent, open, iby) do
+    [
+      _indent(indent),
+      "<",
+      to_string(tag),
+      " ",
+      atts,
+      ">",
+      "\n",
+      _construct(content, indent + iby, [], iby),
+      _indent(indent),
+      "</",
+      to_string(tag),
+      ">\n",
+      _construct(rest, indent, open, iby)
+    ]
   end
 
   defp _indent(n), do: Stream.cycle([" "]) |> Enum.take(n)
 
-  defp _void_tag( tag, rest, indent, open, iby) do
+  defp _void_tag(tag, rest, indent, open, iby) do
     [_indent(indent), tag, _construct(rest, indent, open, iby)]
   end
 
   defp _void_tag_with_atts(tag, atts, rest, indent, open, iby) do
-    [_indent(indent), tag, atts, " />", "\n", _construct(rest, indent, open, iby)]
+    [_indent(indent), tag, atts, ">", "\n", _construct(rest, indent, open, iby)]
   end
 end


### PR DESCRIPTION
Although void elements are allowed to have a trailing slash, the W3C Validator will issue a warning in that case, as it's now recommended to avoid trailing slash on void elements:

<img width="915" alt="Captura de pantalla 2023-04-25 a las 12 49 03" src="https://user-images.githubusercontent.com/2629/234254694-49e1c106-9570-4c68-bf0b-745dbbbbef2a.png">

More information here:

https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements

