### PR TITLE
Rename EarmarkParser to Earmark.Parser to avoid conflicts

### DIFF
--- a/bench/simple_data_bench.exs
+++ b/bench/simple_data_bench.exs
@@ -499,7 +499,7 @@ defmodule Bench.SimpleDataBench do
   end
 
   bench "01 as_ast|>transform" do
-    {:ok, ast, []} = EarmarkParser.as_ast(@readme_md)
+    {:ok, ast, []} = Earmark.Parser.as_ast(@readme_md)
     Earmark.Transform.transform(ast)
   end
 end

--- a/lib/earmark.ex
+++ b/lib/earmark.ex
@@ -22,7 +22,7 @@ defmodule Earmark do
 
   ### Abstract Syntax Tree and Rendering
 
-  The AST generation has now been moved out to [`EarmarkParser`](https://github.com/robertdober/earmark_parser)
+  The AST generation has now been moved out to [`Earmark.Parser`](https://github.com/robertdober/earmark_parser)
   which is installed as a dependency.
 
   This brings some changes to this documentation and also deprecates the usage of `Earmark.as_ast`
@@ -30,27 +30,27 @@ defmodule Earmark do
   Earmark takes care of rendering the AST to HTML, exposing some AST Transformation Tools and providing a CLI as escript.
 
   Therefore you will not find a detailed description of the supported Markdown here anymore as this is done in
-  [here](https://hexdocs.pm/earmark_parser/EarmarkParser.html)
+  [here](https://hexdocs.pm/earmark_parser/Earmark.Parser.html)
 
 
 
   #### Earmark.as_ast
 
-  WARNING: This is just a proxy towards `EarmarkParser.as_ast` and is deprecated, it will be removed in version 1.5!
+  WARNING: This is just a proxy towards `Earmark.Parser.as_ast` and is deprecated, it will be removed in version 1.5!
 
   Replace your calls to `Earmark.as_ast` with `EarmarkParse.as_ast` as soon as possible.
 
-  **N.B.** If all you use is `Earmark.as_ast` consider _only_ using `EarmarkParser`.
+  **N.B.** If all you use is `Earmark.as_ast` consider _only_ using `Earmark.Parser`.
 
-  Also please refer yourself to the documentation of [`EarmarkParser`](https://hexdocs.pm/earmark_parser/EarmarkParser.html)
+  Also please refer yourself to the documentation of [`Earmark.Parser`](https://hexdocs.pm/earmark_parser/Earmark.Parser.html)
 
 
   The function is described below and the other two API functions `as_html` and `as_html!` are now based upon
   the structure of the result of `as_ast`.
 
-      {:ok, ast, []}                   = EarmarkParser.as_ast(markdown)
-      {:ok, ast, deprecation_messages} = EarmarkParser.as_ast(markdown)
-      {:error, ast, error_messages}    = EarmarkParser.as_ast(markdown)
+      {:ok, ast, []}                   = Earmark.Parser.as_ast(markdown)
+      {:ok, ast, deprecation_messages} = Earmark.Parser.as_ast(markdown)
+      {:error, ast, error_messages}    = Earmark.Parser.as_ast(markdown)
 
   #### Earmark.as_html
 
@@ -72,11 +72,11 @@ defmodule Earmark do
 
       {status, html_doc, errors} = Earmark.as_html(markdown, options)
       html_doc = Earmark.as_html!(markdown, options)
-      {status, ast, errors} = EarmarkParser.as_ast(markdown, options)
+      {status, ast, errors} = Earmark.Parser.as_ast(markdown, options)
 
   ### Rendering
 
-  All options passed through to `EarmarkParser.as_ast` are defined therein, however some options concern only
+  All options passed through to `Earmark.Parser.as_ast` are defined therein, however some options concern only
   the rendering of the returned AST
 
   These are:
@@ -148,7 +148,7 @@ defmodule Earmark do
 
   ```elixir
             markdown
-            |> EarmarkParser.as_ast
+            |> Earmark.Parser.as_ast
             |> Earmark.Transform.map_ast(fun)
             |> Earmark.Transform.transform
   ```
@@ -221,21 +221,21 @@ defmodule Earmark do
   """
 
   alias Earmark.{Internal, Options, Transform}
-  alias Earmark.EarmarkParserProxy, as: Proxy
+  alias Earmark.Earmark.ParserProxy, as: Proxy
 
   defdelegate as_ast!(markdown, options \\ []), to: Internal
   defdelegate as_html(lines, options \\ []), to: Internal
   defdelegate as_html!(lines, options \\ []), to: Internal
 
   @doc """
-  DEPRECATED call `EarmarkParser.as_ast` instead
+  DEPRECATED call `Earmark.Parser.as_ast` instead
   """
   def as_ast(lines, options \\ %Options{}) do
     {status, ast, messages} = _as_ast(lines, options)
 
     message =
       {:warning, 0,
-       "DEPRECATION: Earmark.as_ast will be removed in version 1.5, please use EarmarkParser.as_ast, which is of the same type"}
+       "DEPRECATION: Earmark.as_ast will be removed in version 1.5, please use Earmark.Parser.as_ast, which is of the same type"}
 
     messages1 = [message | messages]
     {status, ast, messages1}

--- a/lib/earmark/earmark_parser_proxy.ex
+++ b/lib/earmark/earmark_parser_proxy.ex
@@ -1,25 +1,25 @@
-defmodule Earmark.EarmarkParserProxy do
+defmodule Earmark.Earmark.ParserProxy do
   @moduledoc ~S"""
-  This acts as a proxy to adapt to changes in `EarmarkParser`'s API
+  This acts as a proxy to adapt to changes in `Earmark.Parser`'s API
 
-  If no changes are needed it can delegate `as_ast` to `EarmarkParser`
+  If no changes are needed it can delegate `as_ast` to `Earmark.Parser`
 
   If changes are needed they will be realised in this modules `as_ast`
   function.
 
-  For that reason `EarmarkParser.as_ast/*` **SHALL NOT** be invoked
+  For that reason `Earmark.Parser.as_ast/*` **SHALL NOT** be invoked
   anywhere else in this code base
   """
 
   @doc ~S"""
-  An adapter to `EarmarkParser.as_ast/*`
+  An adapter to `Earmark.Parser.as_ast/*`
   """
   def as_ast(input, options)
   def as_ast(input, options) when is_list(options)  do
-    EarmarkParser.as_ast(input, options |> Keyword.delete(:smartypants) |> Keyword.delete(:messages))
+    Earmark.Parser.as_ast(input, options |> Keyword.delete(:smartypants) |> Keyword.delete(:messages))
   end
   def as_ast(input, options) when is_map(options)  do
-    EarmarkParser.as_ast(input, options |> Map.delete(:smartypants) |> Map.delete(:messages))
+    Earmark.Parser.as_ast(input, options |> Map.delete(:smartypants) |> Map.delete(:messages))
   end
 
 end

--- a/lib/earmark/internal.ex
+++ b/lib/earmark/internal.ex
@@ -6,11 +6,11 @@ defmodule Earmark.Internal do
   """
 
   alias Earmark.{Error, Message, Options, SysInterface, Transform}
-  alias Earmark.EarmarkParserProxy, as: Proxy
+  alias Earmark.Earmark.ParserProxy, as: Proxy
   import Message, only: [emit_messages: 2]
 
   @doc ~S"""
-  A wrapper to extract the AST from a call to `EarmarkParser.as_ast` if a tuple `{:ok, result, []}` is returned,
+  A wrapper to extract the AST from a call to `Earmark.Parser.as_ast` if a tuple `{:ok, result, []}` is returned,
   raise errors otherwise
 
       iex(1)> as_ast!(["Hello %% annotated"], annotations: "%%")

--- a/lib/earmark/options.ex
+++ b/lib/earmark/options.ex
@@ -1,6 +1,6 @@
 defmodule Earmark.Options do
   @moduledoc """
-  This is a superset of the options that need to be passed into `EarmarkParser.as_ast/2`
+  This is a superset of the options that need to be passed into `Earmark.Parser.as_ast/2`
 
   The following options are proper to `Earmark` only and therefore explained in detail
 
@@ -11,10 +11,10 @@ defmodule Earmark.Options do
   - `smartypants`: boolean use [Smarty Pants](https://daringfireball.net/projects/smartypants/) in the output
   - `ignore_strings`, `postprocessor` and `registered_processors`: processors that modify the AST returned from
 
-     EarmarkParser.as_ast/`2` before rendering (`post` because preprocessing is done on the markdown, e.g. `eex`)
+     Earmark.Parser.as_ast/`2` before rendering (`post` because preprocessing is done on the markdown, e.g. `eex`)
      Refer to the moduledoc of Earmark.`Transform` for details
 
-  All other options are passed onto EarmarkParser.as_ast/`2`
+  All other options are passed onto Earmark.Parser.as_ast/`2`
   """
 
   defstruct annotations: nil,

--- a/lib/earmark/restructure.ex
+++ b/lib/earmark/restructure.ex
@@ -5,7 +5,7 @@ defmodule Earmark.Restructure do
   Walks an AST and allows you to process it (storing details in acc) and/or
   modify it as it is walked.
 
-  items is the AST you got from EarmarkParser.as_ast()
+  items is the AST you got from Earmark.Parser.as_ast()
 
   acc is the initial value of an accumulator that is passed to both
   process_item_fn and process_list_fn and accumulated. If your functions
@@ -52,7 +52,7 @@ defmodule Earmark.Restructure do
       ...(1)>
       ...(1)> text
       ...(1)> """
-      ...(1)> {:ok, ast, []} = EarmarkParser.as_ast(markdown)
+      ...(1)> {:ok, ast, []} = Earmark.Parser.as_ast(markdown)
       ...(1)> Restructure.walk_and_modify_ast(ast, nil, italics_maker, comment_remover)
       {[
         {"p", [],

--- a/lib/earmark/transform.ex
+++ b/lib/earmark/transform.ex
@@ -3,7 +3,7 @@ defmodule Earmark.Transform do
 
   alias Earmark.Options
   alias Earmark.TagSpecificProcessors, as: TSP
-  alias Earmark.EarmarkParserProxy, as: Proxy
+  alias Earmark.Earmark.ParserProxy, as: Proxy
   alias __MODULE__.Pop
 
   @compact_tags ~w[a code em strong del]
@@ -14,7 +14,7 @@ defmodule Earmark.Transform do
   @moduledoc ~S"""
   #### Structure Conserving Transformers
 
-  For the convenience of processing the output of `EarmarkParser.as_ast` we expose two structure conserving
+  For the convenience of processing the output of `Earmark.Parser.as_ast` we expose two structure conserving
   mappers.
 
   ##### `map_ast`
@@ -280,12 +280,12 @@ defmodule Earmark.Transform do
   @doc ~S"""
   This is a structure conserving transformation
 
-      iex(11)> {:ok, ast, _} = EarmarkParser.as_ast("- one\n- two\n")
+      iex(11)> {:ok, ast, _} = Earmark.Parser.as_ast("- one\n- two\n")
       ...(11)> map_ast(ast, &(&1))
       [{"ul", [], [{"li", [], ["one"], %{}}, {"li", [], ["two"], %{}}], %{}}]
 
   A more useful transformation
-      iex(12)> {:ok, ast, _} = EarmarkParser.as_ast("- one\n- two\n")
+      iex(12)> {:ok, ast, _} = Earmark.Parser.as_ast("- one\n- two\n")
       ...(12)> fun = fn {_, _, _, _}=n -> Earmark.AstTools.merge_atts_in_node(n, class: "private")
       ...(12)>           string      -> string end
       ...(12)> map_ast(ast, fun)
@@ -293,7 +293,7 @@ defmodule Earmark.Transform do
 
   However the usage of the `ignore_strings` option renders the code much simpler
 
-      iex(13)> {:ok, ast, _} = EarmarkParser.as_ast("- one\n- two\n")
+      iex(13)> {:ok, ast, _} = Earmark.Parser.as_ast("- one\n- two\n")
       ...(13)> map_ast(ast, &Earmark.AstTools.merge_atts_in_node(&1, class: "private"), true)
       [{"ul", [{"class", "private"}], [{"li", [{"class", "private"}], ["one"], %{}}, {"li", [{"class", "private"}], ["two"], %{}}], %{}}]
   """
@@ -305,7 +305,7 @@ defmodule Earmark.Transform do
   This too is a structure perserving transformation but a value is passed to the mapping function as an accumulator, and the mapping
   function needs to return the new node and the accumulator as a tuple, here is a simple example
 
-      iex(14)> {:ok, ast, _} = EarmarkParser.as_ast("- 1\n\n2\n- 3\n")
+      iex(14)> {:ok, ast, _} = Earmark.Parser.as_ast("- 1\n\n2\n- 3\n")
       ...(14)> summer = fn {"li", _, [v], _}=n, s -> {v_, _} = Integer.parse(v); {n, s + v_}
       ...(14)>             n, s -> {n, s} end
       ...(14)> map_ast_with(ast, 0, summer, true)
@@ -313,7 +313,7 @@ defmodule Earmark.Transform do
 
   or summing all numbers
 
-      iex(15)> {:ok, ast, _} = EarmarkParser.as_ast("- 1\n\n2\n- 3\n")
+      iex(15)> {:ok, ast, _} = Earmark.Parser.as_ast("- 1\n\n2\n- 3\n")
       ...(15)> summer = fn {_, _, _, _}=n, s -> {n, s}
       ...(15)>             n, s -> {n_, _} = Integer.parse(n); {"*", s+n_} end
       ...(15)> map_ast_with(ast, 0, summer)

--- a/lib/earmark_parser.ex
+++ b/lib/earmark_parser.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser do
+defmodule Earmark.Parser do
   @type ast_meta :: map()
   @type ast_tag :: binary()
   @type ast_attribute_name :: binary()
@@ -13,21 +13,21 @@ defmodule EarmarkParser do
 
   ### API
 
-  #### EarmarkParser.as_ast
+  #### Earmark.Parser.as_ast
 
   This is the structure of the result of `as_ast`.
 
-      {:ok, ast, []}                   = EarmarkParser.as_ast(markdown)
-      {:ok, ast, deprecation_messages} = EarmarkParser.as_ast(markdown)
-      {:error, ast, error_messages}    = EarmarkParser.as_ast(markdown)
+      {:ok, ast, []}                   = Earmark.Parser.as_ast(markdown)
+      {:ok, ast, deprecation_messages} = Earmark.Parser.as_ast(markdown)
+      {:error, ast, error_messages}    = Earmark.Parser.as_ast(markdown)
 
   For examples see the functiondoc below.
 
   #### Options
 
-  Options can be passed into `as_ast/2` according to the documentation of `EarmarkParser.Options`.
+  Options can be passed into `as_ast/2` according to the documentation of `Earmark.Parser.Options`.
 
-      {status, ast, errors} = EarmarkParser.as_ast(markdown, options)
+      {status, ast, errors} = Earmark.Parser.as_ast(markdown, options)
 
   ## Supports
 
@@ -43,24 +43,24 @@ defmodule EarmarkParser do
 
   ##### Oneline HTML Link tags
 
-      iex(1)> EarmarkParser.as_ast(~s{<a href="href">link</a>})
+      iex(1)> Earmark.Parser.as_ast(~s{<a href="href">link</a>})
       {:ok, [{"a", [{"href", "href"}], ["link"], %{verbatim: true}}], []}
 
   ##### Markdown links
 
   New style ...
 
-      iex(2)> EarmarkParser.as_ast(~s{[title](destination)})
+      iex(2)> Earmark.Parser.as_ast(~s{[title](destination)})
       {:ok,  [{"p", [], [{"a", [{"href", "destination"}], ["title"], %{}}], %{}}], []}
 
   and old style
 
-      iex(3)> EarmarkParser.as_ast("[foo]: /url \"title\"\n\n[foo]\n")
+      iex(3)> Earmark.Parser.as_ast("[foo]: /url \"title\"\n\n[foo]\n")
       {:ok, [{"p", [], [{"a", [{"href", "/url"}, {"title", "title"}], ["foo"], %{}}], %{}}], []}
 
   #### Autolinks
 
-      iex(4)> EarmarkParser.as_ast("<https://elixir-lang.com>")
+      iex(4)> Earmark.Parser.as_ast("<https://elixir-lang.com>")
       {:ok, [{"p", [], [{"a", [{"href", "https://elixir-lang.com"}], ["https://elixir-lang.com"], %{}}], %{}}], []}
 
   #### Additional link parsing via options
@@ -70,12 +70,12 @@ defmodule EarmarkParser do
 
   **N.B.** that the `pure_links` option is `true` by default
 
-      iex(5)> EarmarkParser.as_ast("https://github.com")
+      iex(5)> Earmark.Parser.as_ast("https://github.com")
       {:ok, [{"p", [], [{"a", [{"href", "https://github.com"}], ["https://github.com"], %{}}], %{}}], []}
 
   But can be deactivated
 
-      iex(6)> EarmarkParser.as_ast("https://github.com", pure_links: false)
+      iex(6)> Earmark.Parser.as_ast("https://github.com", pure_links: false)
       {:ok, [{"p", [], ["https://github.com"], %{}}], []}
 
 
@@ -83,12 +83,12 @@ defmodule EarmarkParser do
 
     are disabled by default
 
-      iex(7)> EarmarkParser.as_ast("[[page]]")
+      iex(7)> Earmark.Parser.as_ast("[[page]]")
       {:ok, [{"p", [], ["[[page]]"], %{}}], []}
 
     and can be enabled
 
-      iex(8)> EarmarkParser.as_ast("[[page]]", wikilinks: true)
+      iex(8)> Earmark.Parser.as_ast("[[page]]", wikilinks: true)
       {:ok, [{"p", [], [{"a", [{"href", "page"}], ["page"], %{wikilink: true}}], %{}}], []}
 
 
@@ -98,21 +98,21 @@ defmodule EarmarkParser do
 
   Therefore we will get
 
-      iex(9)> EarmarkParser.as_ast("H~2~O or a^n^ + b^n^ = c^n^")
+      iex(9)> Earmark.Parser.as_ast("H~2~O or a^n^ + b^n^ = c^n^")
       {:ok, [{"p", [], ["H~2~O or a^n^ + b^n^ = c^n^"], %{}}], []}
 
   But by specifying `sub_sup: true`
 
-      iex(10)> EarmarkParser.as_ast("H~2~O or a^n^ + b^n^ = c^n^", sub_sup: true)
+      iex(10)> Earmark.Parser.as_ast("H~2~O or a^n^ + b^n^ = c^n^", sub_sup: true)
       {:ok, [{"p", [], ["H", {"sub", [], ["2"], %{}}, "O or a", {"sup", [], ["n"], %{}}, " + b", {"sup", [], ["n"], %{}}, " = c", {"sup", [], ["n"], %{}}], %{}}], []}
 
   ### Github Flavored Markdown
 
-  GFM is supported by default, however as GFM is a moving target and all GFM extension do not make sense in a general context, EarmarkParser does not support all of it, here is a list of what is supported:
+  GFM is supported by default, however as GFM is a moving target and all GFM extension do not make sense in a general context, Earmark.Parser does not support all of it, here is a list of what is supported:
 
   #### Strike Through
 
-      iex(11)> EarmarkParser.as_ast("~~hello~~")
+      iex(11)> Earmark.Parser.as_ast("~~hello~~")
       {:ok, [{"p", [], [{"del", [], ["hello"], %{}}], %{}}], []}
 
   #### GFM Tables
@@ -159,7 +159,7 @@ defmodule EarmarkParser do
   put before the language string.
 
   Prism.js for example needs a class `language-elixir`. In order to achieve that goal you can add `language-`
-  as a `code_class_prefix` to `EarmarkParser.Options`.
+  as a `code_class_prefix` to `Earmark.Parser.Options`.
 
   In the following example we want more than one additional class, so we add more prefixes.
 
@@ -167,7 +167,7 @@ defmodule EarmarkParser do
       ...(15)>    "```elixir",
       ...(15)>    " @tag :hello",
       ...(15)>    "```"
-      ...(15)> ] |> as_ast(%EarmarkParser.Options{code_class_prefix: "lang- language-"})
+      ...(15)> ] |> as_ast(%Earmark.Parser.Options{code_class_prefix: "lang- language-"})
       {:ok, [{"pre", [], [{"code", [{"class", "elixir lang-elixir language-elixir"}], [" @tag :hello"], %{}}], %{}}], []}
 
 
@@ -290,20 +290,20 @@ defmodule EarmarkParser do
   E.g.
 
       iex(20)> lines = [ "<div><span>", "some</span><text>", "</div>more text" ]
-      ...(20)> EarmarkParser.as_ast(lines)
+      ...(20)> Earmark.Parser.as_ast(lines)
       {:ok, [{"div", [], ["<span>", "some</span><text>"], %{verbatim: true}}, "more text"], []}
 
   And a line starting with an opening tag and ending with the corresponding closing tag is parsed in similar
   fashion
 
-      iex(21)> EarmarkParser.as_ast(["<span class=\"superspan\">spaniel</span>"])
+      iex(21)> Earmark.Parser.as_ast(["<span class=\"superspan\">spaniel</span>"])
       {:ok, [{"span", [{"class", "superspan"}], ["spaniel"], %{verbatim: true}}], []}
 
   What is HTML?
 
   We differ from strict GFM by allowing **all** tags not only HTML5 tags this holds for one liners....
 
-      iex(22)> {:ok, ast, []} = EarmarkParser.as_ast(["<stupid />", "<not>better</not>"])
+      iex(22)> {:ok, ast, []} = Earmark.Parser.as_ast(["<stupid />", "<not>better</not>"])
       ...(22)> ast
       [
         {"stupid", [], [], %{verbatim: true}},
@@ -311,7 +311,7 @@ defmodule EarmarkParser do
 
   and for multi line blocks
 
-      iex(23)> {:ok, ast, []} = EarmarkParser.as_ast([ "<hello>", "world", "</hello>"])
+      iex(23)> {:ok, ast, []} = Earmark.Parser.as_ast([ "<hello>", "world", "</hello>"])
       ...(23)> ast
       [{"hello", [], ["world"], %{verbatim: true}}]
 
@@ -322,7 +322,7 @@ defmodule EarmarkParser do
 
   E.g.
 
-      iex(24)> EarmarkParser.as_ast(" <!-- Comment\ncomment line\ncomment --> text -->\nafter")
+      iex(24)> Earmark.Parser.as_ast(" <!-- Comment\ncomment line\ncomment --> text -->\nafter")
       {:ok, [{:comment, [], [" Comment", "comment line", "comment "], %{comment: true}}, {"p", [], ["after"], %{}}], []}
 
 
@@ -333,7 +333,7 @@ defmodule EarmarkParser do
   which we can only have in a [loose one](https://babelmark.github.io/?text=*+aa%0A++%0A++%3E+Second)
 
   Or a headline in a [tight list item](https://babelmark.github.io/?text=*+bb%0A++%23+Headline) which, again is only available in the
-  [loose version](https://babelmark.github.io/?text=*+bb%0A%0A++%23+Headline) in EarmarkParser.
+  [loose version](https://babelmark.github.io/?text=*+bb%0A%0A++%23+Headline) in Earmark.Parser.
 
   furthermore [this example](https://babelmark.github.io/?text=*+aa%0A++%60%60%60%0ASecond%0A++%60%60%60) demonstrates how weird
   and definitely not useful GFM's own interpretation can get.
@@ -418,25 +418,25 @@ defmodule EarmarkParser do
   format.
 
       iex(33)> markdown = "[link](url) {: .classy}"
-      ...(33)> EarmarkParser.as_ast(markdown)
+      ...(33)> Earmark.Parser.as_ast(markdown)
       { :ok, [{"p", [], [{"a", [{"class", "classy"}, {"href", "url"}], ["link"], %{}}], %{}}], []}
 
   For both cases, malformed attributes are ignored and warnings are issued.
 
-      iex(34)> [ "Some text", "{:hello}" ] |> Enum.join("\n") |> EarmarkParser.as_ast()
+      iex(34)> [ "Some text", "{:hello}" ] |> Enum.join("\n") |> Earmark.Parser.as_ast()
       {:error, [{"p", [], ["Some text"], %{}}], [{:warning, 2,"Illegal attributes [\"hello\"] ignored in IAL"}]}
 
   It is possible to escape the IAL in both forms if necessary
 
       iex(35)> markdown = "[link](url)\\{: .classy}"
-      ...(35)> EarmarkParser.as_ast(markdown)
+      ...(35)> Earmark.Parser.as_ast(markdown)
       {:ok, [{"p", [], [{"a", [{"href", "url"}], ["link"], %{}}, "{: .classy}"], %{}}], []}
 
   This of course is not necessary in code blocks or text lines
   containing an IAL-like string, as in the following example
 
       iex(36)> markdown = "hello {:world}"
-      ...(36)> EarmarkParser.as_ast(markdown)
+      ...(36)> Earmark.Parser.as_ast(markdown)
       {:ok, [{"p", [], ["hello {:world}"], %{}}], []}
 
   ## Limitations
@@ -566,19 +566,19 @@ defmodule EarmarkParser do
 
   """
 
-  alias EarmarkParser.Options
-  import EarmarkParser.Message, only: [sort_messages: 1]
+  alias Earmark.Parser.Options
+  import Earmark.Parser.Message, only: [sort_messages: 1]
 
   @doc """
       iex(42)> markdown = "My `code` is **best**"
-      ...(42)> {:ok, ast, []} = EarmarkParser.as_ast(markdown)
+      ...(42)> {:ok, ast, []} = Earmark.Parser.as_ast(markdown)
       ...(42)> ast
       [{"p", [], ["My ", {"code", [{"class", "inline"}], ["code"], %{}}, " is ", {"strong", [], ["best"], %{}}], %{}}]
 
 
 
       iex(43)> markdown = "```elixir\\nIO.puts 42\\n```"
-      ...(43)> {:ok, ast, []} = EarmarkParser.as_ast(markdown, code_class_prefix: "lang-")
+      ...(43)> {:ok, ast, []} = Earmark.Parser.as_ast(markdown, code_class_prefix: "lang-")
       ...(43)> ast
       [{"pre", [], [{"code", [{"class", "elixir lang-elixir"}], ["IO.puts 42"], %{}}], %{}}]
 
@@ -618,12 +618,12 @@ defmodule EarmarkParser do
   end
 
   defp _as_ast(lines, options) do
-    {blocks, context} = EarmarkParser.Parser.parse_markdown(lines, Options.normalize(options))
-    EarmarkParser.AstRenderer.render(blocks, context)
+    {blocks, context} = Earmark.Parser.Parser.parse_markdown(lines, Options.normalize(options))
+    Earmark.Parser.AstRenderer.render(blocks, context)
   end
 
   @doc """
-    Accesses current hex version of the `EarmarkParser` application. Convenience for
+    Accesses current hex version of the `Earmark.Parser` application. Convenience for
     `iex` usage.
   """
   def version() do

--- a/lib/earmark_parser/ast/emitter.ex
+++ b/lib/earmark_parser/ast/emitter.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Ast.Emitter do
+defmodule Earmark.Parser.Ast.Emitter do
   @moduledoc false
 
   def emit(tag, content \\ [], atts \\ [], meta \\ %{})

--- a/lib/earmark_parser/ast/inline.ex
+++ b/lib/earmark_parser/ast/inline.ex
@@ -1,19 +1,19 @@
-defmodule EarmarkParser.Ast.Inline do
+defmodule Earmark.Parser.Ast.Inline do
   @moduledoc false
 
-  alias EarmarkParser.{Context, Message, Parser}
-  alias EarmarkParser.Helpers.PureLinkHelpers
+  alias Earmark.Parser.{Context, Message, Parser}
+  alias Earmark.Parser.Helpers.PureLinkHelpers
   alias Parser.LinkParser
 
-  import EarmarkParser.Ast.Emitter
-  import EarmarkParser.Ast.Renderer.AstWalker
-  import EarmarkParser.Helpers
-  import EarmarkParser.Helpers.AttrParser
-  import EarmarkParser.Helpers.StringHelpers, only: [behead: 2]
-  import EarmarkParser.Helpers.AstHelpers
+  import Earmark.Parser.Ast.Emitter
+  import Earmark.Parser.Ast.Renderer.AstWalker
+  import Earmark.Parser.Helpers
+  import Earmark.Parser.Helpers.AttrParser
+  import Earmark.Parser.Helpers.StringHelpers, only: [behead: 2]
+  import Earmark.Parser.Helpers.AstHelpers
   import Context, only: [set_value: 2]
 
-  @typep conversion_data :: {String.t(), non_neg_integer(), EarmarkParser.Context.t(), boolean()}
+  @typep conversion_data :: {String.t(), non_neg_integer(), Earmark.Parser.Context.t(), boolean()}
   def convert(src, lnb, context)
 
   def convert(list, lnb, context) when is_list(list) do

--- a/lib/earmark_parser/ast/renderer/ast_walker.ex
+++ b/lib/earmark_parser/ast/renderer/ast_walker.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Ast.Renderer.AstWalker do
+defmodule Earmark.Parser.Ast.Renderer.AstWalker do
   
   @moduledoc false
 

--- a/lib/earmark_parser/ast/renderer/footnote_renderer.ex
+++ b/lib/earmark_parser/ast/renderer/footnote_renderer.ex
@@ -1,6 +1,6 @@
-defmodule EarmarkParser.Ast.Renderer.FootnoteRenderer do
-  import EarmarkParser.Ast.Emitter
-  alias EarmarkParser.{AstRenderer, Block, Context, Message}
+defmodule Earmark.Parser.Ast.Renderer.FootnoteRenderer do
+  import Earmark.Parser.Ast.Emitter
+  alias Earmark.Parser.{AstRenderer, Block, Context, Message}
   import Context, only: [clear_value: 1, prepend: 2]
 
   @moduledoc false
@@ -23,26 +23,27 @@ defmodule EarmarkParser.Ast.Renderer.FootnoteRenderer do
     prepend(context, ast) |> Message.add_messages(errors)
   end
 
-  defp _render_footnote_def(%Block.FnDef{blocks: blocks, id: id}, {ast, errors, context}=acc) do
+  defp _render_footnote_def(%Block.FnDef{blocks: blocks, id: id}, {ast, errors, context} = acc) do
     if MapSet.member?(context.referenced_footnote_ids, id) do
       context1 = AstRenderer.render(blocks, clear_value(context))
       a_attrs = %{title: "return to article", class: "reversefootnote", href: "#fnref:#{id}"}
+
       footnote_li_ast =
-        emit("li", [emit("a", ["&#x21A9;"], a_attrs) | context1.value],
-         id: "fn:#{id}")
-      {[footnote_li_ast|ast], MapSet.union(errors, context1.options.messages), context}
+        emit("li", [emit("a", ["&#x21A9;"], a_attrs) | context1.value], id: "fn:#{id}")
+
+      {[footnote_li_ast | ast], MapSet.union(errors, context1.options.messages), context}
     else
       acc
     end
   end
-
 
   defp render_footnote_blocks(footnotes, context) do
     {elements, errors, _} =
       footnotes
       |> Enum.reduce({[], @empty_set, context}, &_render_footnote_def/2)
 
-    {elements|>Enum.reverse, errors}
+    {elements |> Enum.reverse(), errors}
   end
 end
+
 #  SPDX-License-Identifier: Apache-2.0

--- a/lib/earmark_parser/ast/renderer/html_renderer.ex
+++ b/lib/earmark_parser/ast/renderer/html_renderer.ex
@@ -1,8 +1,8 @@
-defmodule EarmarkParser.Ast.Renderer.HtmlRenderer do
+defmodule Earmark.Parser.Ast.Renderer.HtmlRenderer do
 
-  import EarmarkParser.Context, only: [prepend: 2]
-  import EarmarkParser.Helpers.HtmlParser
-  import EarmarkParser.Helpers.AstHelpers, only: [annotate: 2]
+  import Earmark.Parser.Context, only: [prepend: 2]
+  import Earmark.Parser.Helpers.HtmlParser
+  import Earmark.Parser.Helpers.AstHelpers, only: [annotate: 2]
 
   @moduledoc false
 

--- a/lib/earmark_parser/ast/renderer/table_renderer.ex
+++ b/lib/earmark_parser/ast/renderer/table_renderer.ex
@@ -1,10 +1,10 @@
-defmodule EarmarkParser.Ast.Renderer.TableRenderer do
+defmodule Earmark.Parser.Ast.Renderer.TableRenderer do
   @moduledoc false
 
-  alias EarmarkParser.Ast.Inline
-  alias EarmarkParser.Context
+  alias Earmark.Parser.Ast.Inline
+  alias Earmark.Parser.Context
 
-  import EarmarkParser.Ast.Emitter
+  import Earmark.Parser.Ast.Emitter
 
   def render_header(header, lnb, aligns, context) do
     {th_ast, context1} =

--- a/lib/earmark_parser/ast_renderer.ex
+++ b/lib/earmark_parser/ast_renderer.ex
@@ -1,14 +1,14 @@
-defmodule EarmarkParser.AstRenderer do
-  alias EarmarkParser.Block
-  alias EarmarkParser.Context
-  alias EarmarkParser.Options
+defmodule Earmark.Parser.AstRenderer do
+  alias Earmark.Parser.Block
+  alias Earmark.Parser.Context
+  alias Earmark.Parser.Options
 
   import Context, only: [clear_value: 1, modify_value: 2, prepend: 2, prepend: 3]
 
-  import EarmarkParser.Ast.Emitter
-  import EarmarkParser.Ast.Inline, only: [convert: 3]
-  import EarmarkParser.Helpers.AstHelpers
-  import EarmarkParser.Ast.Renderer.{HtmlRenderer, FootnoteRenderer, TableRenderer}
+  import Earmark.Parser.Ast.Emitter
+  import Earmark.Parser.Ast.Inline, only: [convert: 3]
+  import Earmark.Parser.Helpers.AstHelpers
+  import Earmark.Parser.Ast.Renderer.{HtmlRenderer, FootnoteRenderer, TableRenderer}
 
   @moduledoc false
 

--- a/lib/earmark_parser/block/block_quote.ex
+++ b/lib/earmark_parser/block/block_quote.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.BlockQuote do
+defmodule Earmark.Parser.Block.BlockQuote do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: nil, blocks: []
 end

--- a/lib/earmark_parser/block/code.ex
+++ b/lib/earmark_parser/block/code.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.Code do
+defmodule Earmark.Parser.Block.Code do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: nil, lines: [], language: nil
 end

--- a/lib/earmark_parser/block/fn_def.ex
+++ b/lib/earmark_parser/block/fn_def.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.FnDef do
+defmodule Earmark.Parser.Block.FnDef do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: nil, id: nil, number: nil, blocks: []
 end

--- a/lib/earmark_parser/block/fn_list.ex
+++ b/lib/earmark_parser/block/fn_list.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.FnList do
+defmodule Earmark.Parser.Block.FnList do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: ".footnotes", blocks: []
 end

--- a/lib/earmark_parser/block/heading.ex
+++ b/lib/earmark_parser/block/heading.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.Heading do
+defmodule Earmark.Parser.Block.Heading do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: nil, content: nil, level: nil
 end

--- a/lib/earmark_parser/block/html.ex
+++ b/lib/earmark_parser/block/html.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.Html do
+defmodule Earmark.Parser.Block.Html do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: nil, html: [], tag: nil
 end

--- a/lib/earmark_parser/block/html_comment.ex
+++ b/lib/earmark_parser/block/html_comment.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.HtmlComment do
+defmodule Earmark.Parser.Block.HtmlComment do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: nil, lines: []
 end

--- a/lib/earmark_parser/block/html_oneline.ex
+++ b/lib/earmark_parser/block/html_oneline.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.HtmlOneline do
+defmodule Earmark.Parser.Block.HtmlOneline do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: nil, html: ""
 end

--- a/lib/earmark_parser/block/ial.ex
+++ b/lib/earmark_parser/block/ial.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.Ial do
+defmodule Earmark.Parser.Block.Ial do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: nil, content: nil, verbatim: ""
 end

--- a/lib/earmark_parser/block/id_def.ex
+++ b/lib/earmark_parser/block/id_def.ex
@@ -1,5 +1,6 @@
-defmodule EarmarkParser.Block.IdDef do
+defmodule Earmark.Parser.Block.IdDef do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: nil, id: nil, url: nil, title: nil
 end
+
 #  SPDX-License-Identifier: Apache-2.0

--- a/lib/earmark_parser/block/list.ex
+++ b/lib/earmark_parser/block/list.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.List do
+defmodule Earmark.Parser.Block.List do
   @moduledoc false
 
   defstruct annotation: nil,

--- a/lib/earmark_parser/block/list_item.ex
+++ b/lib/earmark_parser/block/list_item.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.ListItem do
+defmodule Earmark.Parser.Block.ListItem do
   @moduledoc false
   defstruct attrs: nil,
             blocks: [],

--- a/lib/earmark_parser/block/para.ex
+++ b/lib/earmark_parser/block/para.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.Para do
+defmodule Earmark.Parser.Block.Para do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: nil, lines: []
 end

--- a/lib/earmark_parser/block/ruler.ex
+++ b/lib/earmark_parser/block/ruler.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.Ruler do
+defmodule Earmark.Parser.Block.Ruler do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: nil, type: nil
 end

--- a/lib/earmark_parser/block/table.ex
+++ b/lib/earmark_parser/block/table.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Block.Table do
+defmodule Earmark.Parser.Block.Table do
   @moduledoc false
   defstruct lnb: 0, annotation: nil, attrs: nil, rows: [], header: nil, alignments: []
 
@@ -6,4 +6,5 @@ defmodule EarmarkParser.Block.Table do
     %__MODULE__{alignments: Elixir.List.duplicate(:left, n)}
   end
 end
+
 #  SPDX-License-Identifier: Apache-2.0

--- a/lib/earmark_parser/block/text.ex
+++ b/lib/earmark_parser/block/text.ex
@@ -1,5 +1,6 @@
-defmodule EarmarkParser.Block.Text do
+defmodule Earmark.Parser.Block.Text do
   @moduledoc false
   defstruct attrs: nil, lnb: 0, annotation: nil, line: ""
 end
+
 #  SPDX-License-Identifier: Apache-2.0

--- a/lib/earmark_parser/context.ex
+++ b/lib/earmark_parser/context.ex
@@ -1,16 +1,16 @@
-defmodule EarmarkParser.Context do
+defmodule Earmark.Parser.Context do
   @moduledoc false
-  alias EarmarkParser.Options
+  alias Earmark.Parser.Options
 
   @type t :: %__MODULE__{
-          options: EarmarkParser.Options.t(),
+          options: Earmark.Parser.Options.t(),
           links: map(),
           footnotes: map(),
           referenced_footnote_ids: MapSet.t(String.t()),
           value: String.t() | [String.t()]
         }
 
-  defstruct options: %EarmarkParser.Options{},
+  defstruct options: %Earmark.Parser.Options{},
             links: Map.new(),
             rules: nil,
             footnotes: Map.new(),
@@ -87,7 +87,7 @@ defmodule EarmarkParser.Context do
 
   # this is called by the command line processor to update
   # the inline-specific rules in light of any options
-  def update_context(context = %EarmarkParser.Context{options: options}) do
+  def update_context(context = %Earmark.Parser.Context{options: options}) do
     %{context | rules: rules_for(options)}
   end
 

--- a/lib/earmark_parser/enum/ext.ex
+++ b/lib/earmark_parser/enum/ext.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Enum.Ext do
+defmodule Earmark.Parser.Enum.Ext do
   @moduledoc ~S"""
     Some extensions of Enum functions
   """

--- a/lib/earmark_parser/helpers.ex
+++ b/lib/earmark_parser/helpers.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Helpers do
+defmodule Earmark.Parser.Helpers do
 
   @moduledoc false
   @doc """

--- a/lib/earmark_parser/helpers/ast_helpers.ex
+++ b/lib/earmark_parser/helpers/ast_helpers.ex
@@ -1,11 +1,11 @@
-defmodule EarmarkParser.Helpers.AstHelpers do
+defmodule Earmark.Parser.Helpers.AstHelpers do
 
   @moduledoc false
 
-  import EarmarkParser.Ast.Emitter
-  import EarmarkParser.Helpers
+  import Earmark.Parser.Ast.Emitter
+  import Earmark.Parser.Helpers
 
-  alias EarmarkParser.Block
+  alias Earmark.Parser.Block
 
   @doc false
   def annotate(node, from_block)

--- a/lib/earmark_parser/helpers/attr_parser.ex
+++ b/lib/earmark_parser/helpers/attr_parser.ex
@@ -1,9 +1,9 @@
-defmodule EarmarkParser.Helpers.AttrParser do
+defmodule Earmark.Parser.Helpers.AttrParser do
 
   @moduledoc false
 
-  import EarmarkParser.Helpers.StringHelpers, only: [ behead: 2 ]
-  import EarmarkParser.Message, only: [add_message: 2]
+  import Earmark.Parser.Helpers.StringHelpers, only: [ behead: 2 ]
+  import Earmark.Parser.Message, only: [add_message: 2]
 
 
   @type errorlist :: list(String.t)

--- a/lib/earmark_parser/helpers/html_parser.ex
+++ b/lib/earmark_parser/helpers/html_parser.ex
@@ -1,9 +1,9 @@
-defmodule EarmarkParser.Helpers.HtmlParser do
+defmodule Earmark.Parser.Helpers.HtmlParser do
 
   @moduledoc false
 
-  import EarmarkParser.Helpers.StringHelpers, only: [behead: 2]
-  import EarmarkParser.LineScanner, only: [void_tag?: 1]
+  import Earmark.Parser.Helpers.StringHelpers, only: [behead: 2]
+  import Earmark.Parser.LineScanner, only: [void_tag?: 1]
 
   def parse_html(lines)
   def parse_html([tag_line|rest]) do

--- a/lib/earmark_parser/helpers/leex_helpers.ex
+++ b/lib/earmark_parser/helpers/leex_helpers.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Helpers.LeexHelpers do
+defmodule Earmark.Parser.Helpers.LeexHelpers do
 
   @moduledoc false
   @doc """

--- a/lib/earmark_parser/helpers/line_helpers.ex
+++ b/lib/earmark_parser/helpers/line_helpers.ex
@@ -1,8 +1,8 @@
-defmodule EarmarkParser.Helpers.LineHelpers do
+defmodule Earmark.Parser.Helpers.LineHelpers do
 
   @moduledoc false
 
-  alias EarmarkParser.Line
+  alias Earmark.Parser.Line
 
   def blank?(%Line.Blank{}),   do: true
   def blank?(_),               do: false

--- a/lib/earmark_parser/helpers/lookahead_helpers.ex
+++ b/lib/earmark_parser/helpers/lookahead_helpers.ex
@@ -1,8 +1,8 @@
-defmodule EarmarkParser.Helpers.LookaheadHelpers do
+defmodule Earmark.Parser.Helpers.LookaheadHelpers do
 
   @moduledoc false
 
-  import EarmarkParser.Helpers.LeexHelpers
+  import Earmark.Parser.Helpers.LeexHelpers
 
   @doc """
   Indicates if the _numbered_line_ passed in leaves an inline code block open.

--- a/lib/earmark_parser/helpers/pure_link_helpers.ex
+++ b/lib/earmark_parser/helpers/pure_link_helpers.ex
@@ -1,7 +1,7 @@
-defmodule EarmarkParser.Helpers.PureLinkHelpers do
+defmodule Earmark.Parser.Helpers.PureLinkHelpers do
   @moduledoc false
 
-  import EarmarkParser.Helpers.AstHelpers, only: [render_link: 2]
+  import Earmark.Parser.Helpers.AstHelpers, only: [render_link: 2]
 
   @pure_link_rgx ~r{
     \A

--- a/lib/earmark_parser/helpers/reparse_helpers.ex
+++ b/lib/earmark_parser/helpers/reparse_helpers.ex
@@ -1,11 +1,11 @@
-defmodule EarmarkParser.Helpers.ReparseHelpers do
+defmodule Earmark.Parser.Helpers.ReparseHelpers do
 
   @moduledoc false
 
-  alias EarmarkParser.Line
+  alias Earmark.Parser.Line
 
   @doc """
-    Extract the verbatim text of `%EarmarkParser.Line.t` elements with less alignment so that
+    Extract the verbatim text of `%Earmark.Parser.Line.t` elements with less alignment so that
     it can be reparsed (as elements of footnotes or indented code)
   """
   # Add additional spaces for any indentation past level 1

--- a/lib/earmark_parser/helpers/string_helpers.ex
+++ b/lib/earmark_parser/helpers/string_helpers.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Helpers.StringHelpers do
+defmodule Earmark.Parser.Helpers.StringHelpers do
 
   @moduledoc false
 

--- a/lib/earmark_parser/helpers/yecc_helpers.ex
+++ b/lib/earmark_parser/helpers/yecc_helpers.ex
@@ -1,7 +1,7 @@
-defmodule EarmarkParser.Helpers.YeccHelpers do
+defmodule Earmark.Parser.Helpers.YeccHelpers do
 
   @moduledoc false
-  import EarmarkParser.Helpers.LeexHelpers, only: [lex: 2]
+  import Earmark.Parser.Helpers.LeexHelpers, only: [lex: 2]
 
   def parse!( text, lexer: lexer, parser: parser ) do
     case parse(text, lexer: lexer, parser: parser) do

--- a/lib/earmark_parser/line.ex
+++ b/lib/earmark_parser/line.ex
@@ -1,4 +1,4 @@
-defmodule EarmarkParser.Line do
+defmodule Earmark.Parser.Line do
 
   @moduledoc false
 

--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -1,7 +1,7 @@
-defmodule EarmarkParser.LineScanner do
+defmodule Earmark.Parser.LineScanner do
   @moduledoc false
 
-  alias EarmarkParser.{Helpers, Line, Options}
+  alias Earmark.Parser.{Helpers, Line, Options}
 
   # This is the re that matches the ridiculous "[id]: url title" syntax
 

--- a/lib/earmark_parser/message.ex
+++ b/lib/earmark_parser/message.ex
@@ -1,8 +1,8 @@
-defmodule EarmarkParser.Message do
+defmodule Earmark.Parser.Message do
   @moduledoc false
 
-  alias EarmarkParser.Context
-  alias EarmarkParser.Options
+  alias Earmark.Parser.Context
+  alias Earmark.Parser.Options
 
   @type message_type :: :error | :warning
   @type t :: {message_type, number, binary}

--- a/lib/earmark_parser/options.ex
+++ b/lib/earmark_parser/options.ex
@@ -1,6 +1,6 @@
-defmodule EarmarkParser.Options do
+defmodule Earmark.Parser.Options do
   # What we use to render
-  defstruct renderer: EarmarkParser.HtmlRenderer,
+  defstruct renderer: Earmark.Parser.HtmlRenderer,
             # Inline style options
             all: false,
             gfm: true,
@@ -38,7 +38,7 @@ defmodule EarmarkParser.Options do
       %{options | smartypants: false},
       [
         {:deprecated, 0,
-         "The smartypants option has no effect anymore and will be removed in EarmarkParser 1.5"}
+         "The smartypants option has no effect anymore and will be removed in Earmark.Parser 1.5"}
         | messages
       ]
     )
@@ -49,7 +49,7 @@ defmodule EarmarkParser.Options do
       %{options | timeout: nil},
       [
         {:deprecated, 0,
-         "The timeout option has no effect anymore and will be removed in EarmarkParser 1.5"}
+         "The timeout option has no effect anymore and will be removed in Earmark.Parser 1.5"}
         | messages
       ]
     )
@@ -60,7 +60,7 @@ defmodule EarmarkParser.Options do
       %{options | pedantic: false},
       [
         {:deprecated, 0,
-         "The pedantic option has no effect anymore and will be removed in EarmarkParser 1.5"}
+         "The pedantic option has no effect anymore and will be removed in Earmark.Parser 1.5"}
         | messages
       ]
     )

--- a/lib/earmark_parser/parser.ex
+++ b/lib/earmark_parser/parser.ex
@@ -1,23 +1,23 @@
-defmodule EarmarkParser.Parser do
+defmodule Earmark.Parser.Parser do
 
   @moduledoc false
-  alias EarmarkParser.{Block, Line, LineScanner, Options}
+  alias Earmark.Parser.{Block, Line, LineScanner, Options}
 
-  import EarmarkParser.Helpers.{AttrParser, LineHelpers, ReparseHelpers}
+  import Earmark.Parser.Helpers.{AttrParser, LineHelpers, ReparseHelpers}
 
-  import EarmarkParser.Helpers.LookaheadHelpers,
+  import Earmark.Parser.Helpers.LookaheadHelpers,
     only: [opens_inline_code: 1, still_inline_code: 2]
 
-  import EarmarkParser.Message, only: [add_message: 2, add_messages: 2]
-  import EarmarkParser.Parser.FootnoteParser, only: [parse_fn_defs: 3]
-  import EarmarkParser.Parser.ListParser, only: [parse_list: 3]
+  import Earmark.Parser.Message, only: [add_message: 2, add_messages: 2]
+  import Earmark.Parser.Parser.FootnoteParser, only: [parse_fn_defs: 3]
+  import Earmark.Parser.Parser.ListParser, only: [parse_list: 3]
 
   @doc """
   Given a markdown document (as either a list of lines or
   a string containing newlines), return a parse tree and
   the context necessary to render the tree.
 
-  The options are a `%EarmarkParser.Options{}` structure. See `as_html!`
+  The options are a `%Earmark.Parser.Options{}` structure. See `as_html!`
   for more details.
   """
   def parse_markdown(lines, options)
@@ -26,8 +26,8 @@ defmodule EarmarkParser.Parser do
     {blocks, links, footnotes, options1} = parse(lines, options, false)
 
     context =
-      %EarmarkParser.Context{options: options1, links: links}
-      |> EarmarkParser.Context.update_context()
+      %Earmark.Parser.Context{options: options1, links: links}
+      |> Earmark.Parser.Context.update_context()
 
     context = put_in(context.footnotes, footnotes)
     context = put_in(context.options, options1)

--- a/lib/earmark_parser/parser/footnote_parser.ex
+++ b/lib/earmark_parser/parser/footnote_parser.ex
@@ -1,5 +1,5 @@
-defmodule EarmarkParser.Parser.FootnoteParser do
-  alias EarmarkParser.{Block, Enum.Ext, Line}
+defmodule Earmark.Parser.Parser.FootnoteParser do
+  alias Earmark.Parser.{Block, Enum.Ext, Line}
 
   @moduledoc false
   def parse_fn_defs([fn_def | rest], result, options) do
@@ -40,7 +40,7 @@ defmodule EarmarkParser.Parser.FootnoteParser do
        ) do
     # `_footnotes1` should be empty but let us not change the shape of parse depending
     # on options or the value of recursive?
-    {inner_blocks, _links, _footnotes1, options1} = EarmarkParser.Parser.parse(Enum.reverse(input), options, true)
+    {inner_blocks, _links, _footnotes1, options1} = Earmark.Parser.Parser.parse(Enum.reverse(input), options, true)
     closed_fn = %{open_fn | blocks: inner_blocks}
     footnotes1 = Map.put(footnotes, closed_fn.id, closed_fn)
 

--- a/lib/earmark_parser/parser/link_parser.ex
+++ b/lib/earmark_parser/parser/link_parser.ex
@@ -1,9 +1,9 @@
-defmodule EarmarkParser.Parser.LinkParser do
+defmodule Earmark.Parser.Parser.LinkParser do
 
   @moduledoc false
-  import EarmarkParser.Helpers.LeexHelpers, only: [tokenize: 2]
-  import EarmarkParser.Helpers.YeccHelpers, only: [parse!: 2]
-  import EarmarkParser.Helpers.StringHelpers, only: [behead: 2]
+  import Earmark.Parser.Helpers.LeexHelpers, only: [tokenize: 2]
+  import Earmark.Parser.Helpers.YeccHelpers, only: [parse!: 2]
+  import Earmark.Parser.Helpers.StringHelpers, only: [behead: 2]
 
   # Hopefully this will go away in v1.3
   # **********************************

--- a/lib/earmark_parser/parser/list_info.ex
+++ b/lib/earmark_parser/parser/list_info.ex
@@ -1,6 +1,6 @@
-defmodule EarmarkParser.Parser.ListInfo do
+defmodule Earmark.Parser.Parser.ListInfo do
 
-  import EarmarkParser.Helpers.LookaheadHelpers, only: [opens_inline_code: 1, still_inline_code: 2]
+  import Earmark.Parser.Helpers.LookaheadHelpers, only: [opens_inline_code: 1, still_inline_code: 2]
 
   @moduledoc false
 
@@ -11,11 +11,11 @@ defmodule EarmarkParser.Parser.ListInfo do
     lines: [],
     loose?: false,
     pending: @not_pending,
-    options: %EarmarkParser.Options{},
+    options: %Earmark.Parser.Options{},
     width: 0
   )
 
-  def new(%EarmarkParser.Line.ListItem{initial_indent: ii, list_indent: width}=item, options) do
+  def new(%Earmark.Parser.Line.ListItem{initial_indent: ii, list_indent: width}=item, options) do
     pending = opens_inline_code(item)
     %__MODULE__{indent: ii, lines: [item.content], options: options, pending: pending, width: width}
   end

--- a/lib/earmark_parser/parser/list_parser.ex
+++ b/lib/earmark_parser/parser/list_parser.ex
@@ -1,9 +1,9 @@
-defmodule EarmarkParser.Parser.ListParser do
-  alias EarmarkParser.{Block, Line, Options}
-  alias EarmarkParser.Parser.ListInfo
+defmodule Earmark.Parser.Parser.ListParser do
+  alias Earmark.Parser.{Block, Line, Options}
+  alias Earmark.Parser.Parser.ListInfo
 
-  import EarmarkParser.Helpers.StringHelpers, only: [behead: 2]
-  import EarmarkParser.Message, only: [add_message: 2]
+  import Earmark.Parser.Helpers.StringHelpers, only: [behead: 2]
+  import Earmark.Parser.Message, only: [add_message: 2]
   import ListInfo
 
   @moduledoc false
@@ -142,7 +142,7 @@ defmodule EarmarkParser.Parser.ListParser do
   defp _finish_list_item([%Block.ListItem{}=item|items], _at_start?, list_info) do
     {blocks, _, _, options1} = list_info.lines
                             |> Enum.reverse
-                            |> EarmarkParser.Parser.parse(%{list_info.options|line: item.lnb}, :list)
+                            |> Earmark.Parser.Parser.parse(%{list_info.options|line: item.lnb}, :list)
     loose1? = _already_loose?(items) || list_info.loose?
     {[%{item | blocks: blocks, loose?: loose1?}|items], options1}
   end

--- a/mix.lock
+++ b/mix.lock
@@ -15,7 +15,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
   "parse_trans": {:hex, :parse_trans, "3.3.1", "16328ab840cc09919bd10dab29e431da3af9e9e7e7e6f0089dd5a2d2820011d8", [:rebar3], [], "hexpm", "07cd9577885f56362d414e8c4c4e6bdf10d43a8767abb92d24cbe8b24c54888b"},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.6", "cf344f5692c82d2cd7554f5ec8fd961548d4fd09e7d22f5b62482e5aeaebd4b0", [:make, :mix, :rebar3], [], "hexpm", "bdb0d2471f453c88ff3908e7686f86f9be327d065cc1ec16fa4540197ea04680"},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.7", "354c321cf377240c7b8716899e182ce4890c5938111a1296add3ec74cf1715df", [:make, :mix, :rebar3], [], "hexpm", "fe4c190e8f37401d30167c8c405eda19469f34577987c76dde613e838bbc67f8"},
   "traverse": {:hex, :traverse, "1.0.1", "5e9b04428e1a82a7de8857ffeecdc37afc94cd702140690c4de2a5e68cbc483d", [:mix], [], "hexpm", "0cf9ec9a974caf36d2d70476af88f6fda469c5d1c08e6341c5cf517b02e01c71"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.7.0", "bc84380c9ab48177092f43ac89e4dfa2c6d62b40b8bd132b1059ecc7232f9a78", [:rebar3], [], "hexpm", "25eee6d67df61960cf6a794239566599b09e17e668d3700247bc498638152521"},
 }

--- a/test/acceptance/restructure/walk_and_modify_ast_test.exs
+++ b/test/acceptance/restructure/walk_and_modify_ast_test.exs
@@ -67,7 +67,7 @@ defmodule Test.Restructure.WalkeAndModifyAstTest do
 
   test "handle_bold_and_italic_from_nonstandard_markdown" do
     markdown = "Hello *boldness* my /italic/ friend!"
-    {:ok, ast, []} = markdown |> EarmarkParser.as_ast()
+    {:ok, ast, []} = markdown |> Earmark.Parser.as_ast()
     processed_ast = ast
                     |> handle_bold()
                     |> handle_italics()
@@ -88,7 +88,7 @@ defmodule Test.Restructure.WalkeAndModifyAstTest do
 
   test "delete_italicized_text" do
     markdown = "Hello *there* my *good* friend!"
-    {:ok, ast, []} = markdown |> EarmarkParser.as_ast()
+    {:ok, ast, []} = markdown |> Earmark.Parser.as_ast()
     {processed_ast, :acc_unused} = Restructure.walk_and_modify_ast(
       ast, :acc_unused, &({&1, &2}), &delete_italicized_text/2)
     assert processed_ast == [{"p", [], ["Hello ", " my ", " friend!"], %{}}]
@@ -120,7 +120,7 @@ defmodule Test.Restructure.WalkeAndModifyAstTest do
 
     text
     """
-    {:ok, ast, []} = EarmarkParser.as_ast(markdown)
+    {:ok, ast, []} = Earmark.Parser.as_ast(markdown)
     Restructure.walk_and_modify_ast(ast, nil, italics_maker, comment_remover)
   end
 
@@ -131,7 +131,7 @@ defmodule Test.Restructure.WalkeAndModifyAstTest do
     Hello world
     """
 
-    {:ok, ast, []} = EarmarkParser.as_ast(markdown)
+    {:ok, ast, []} = Earmark.Parser.as_ast(markdown)
     Restructure.walk_and_modify_ast(ast, nil, fn node, acc -> {node, acc} end)
   end
 end

--- a/test/deprecations/i381-make-as-ast-deprecated_test.exs
+++ b/test/deprecations/i381-make-as-ast-deprecated_test.exs
@@ -8,7 +8,7 @@ defmodule Deprecations.I381DeprecatedTest do
 
       messages = [
         {:warning, 0,
-         "DEPRECATION: Earmark.as_ast will be removed in version 1.5, please use EarmarkParser.as_ast, which is of the same type"}
+         "DEPRECATION: Earmark.as_ast will be removed in version 1.5, please use Earmark.Parser.as_ast, which is of the same type"}
       ]
 
       assert Earmark.as_ast(markdown, []) == {:ok, ast, messages}
@@ -20,7 +20,7 @@ defmodule Deprecations.I381DeprecatedTest do
 
       messages = [
         {:warning, 0,
-         "DEPRECATION: Earmark.as_ast will be removed in version 1.5, please use EarmarkParser.as_ast, which is of the same type"},
+         "DEPRECATION: Earmark.as_ast will be removed in version 1.5, please use Earmark.Parser.as_ast, which is of the same type"},
         {:warning, 1, "Closing unclosed backquotes ` at end of input"}
       ]
 

--- a/test/support/helpers.ex
+++ b/test/support/helpers.ex
@@ -8,7 +8,7 @@ defmodule Support.Helpers do
 
 
   def as_ast(markdown, options \\ []) do
-    EarmarkParser.as_ast(markdown, Options.make_options!(options))
+    Earmark.Parser.as_ast(markdown, Options.make_options!(options))
   end
 
   def as_html(markdown, options \\ []) do

--- a/test/support/html1_helpers.ex
+++ b/test/support/html1_helpers.ex
@@ -1,6 +1,6 @@
 defmodule Support.Html1Helpers do
   def to_html1(markdown, options \\ []) do
-    {status, ast, messages} = EarmarkParser.as_ast(markdown, options)
+    {status, ast, messages} = Earmark.Parser.as_ast(markdown, options)
 
     if System.get_env("DEBUG") do
       IO.inspect({:ast, ast})
@@ -10,7 +10,7 @@ defmodule Support.Html1Helpers do
   end
 
   def to_html2(markdown, options \\ []) do
-    {:ok, ast, []} = EarmarkParser.as_ast(markdown, options)
+    {:ok, ast, []} = Earmark.Parser.as_ast(markdown, options)
 
     if System.get_env("DEBUG") do
       IO.inspect({:ast, ast})

--- a/test/support/performance.ex
+++ b/test/support/performance.ex
@@ -40,7 +40,7 @@ defmodule Support.Performance do
   def convert_file(filename, format \\ :ast, count \\ 1) do
     content = File.read!(Path.join("test/fixtures", filename))
     content1 = Stream.cycle([content]) |> Enum.take(count) |> Enum.join("\n")
-    {:ok, ast, []} = EarmarkParser.as_ast(content1)
+    {:ok, ast, []} = Earmark.Parser.as_ast(content1)
     case format do
       :ast -> ast
       :html -> ast |> Earmark.Transform.transform

--- a/test/transform_test.exs
+++ b/test/transform_test.exs
@@ -7,7 +7,7 @@ defmodule TransformTest do
   describe "annotations" do
     test "annotations" do
       markdown = [ "A joke %% smile", "", "Charming %% in_love" ]
-      {:ok, result_, []} = markdown |> EarmarkParser.as_ast(annotations: "%%")
+      {:ok, result_, []} = markdown |> Earmark.Parser.as_ast(annotations: "%%")
       {result__, _} = result_ |> map_ast_with(nil, &add_smiley/2)
       final = result__ |> Earmark.Transform.transform
       expected = "<p>\nA joke %% smile</p>\n<p>\nCharming %% in_love</p>\n"


### PR DESCRIPTION
Otherwise, if a project depends on both earmark_parser and
earmark at the same time, the module will conflict with each
other.