### PR TITLE
More typespecs

### DIFF
--- a/lib/earmark.ex
+++ b/lib/earmark.ex
@@ -259,6 +259,7 @@ defmodule Earmark do
     Accesses current hex version of the `Earmark` application. Convenience for
     `iex` usage.
   """
+  @spec version :: String.t()
   def version() do
     with {:ok, version} <- :application.get_key(:earmark, :vsn),
          do: to_string(version)

--- a/lib/earmark/cli/implementation.ex
+++ b/lib/earmark/cli/implementation.ex
@@ -36,7 +36,7 @@ defmodule Earmark.Cli.Implementation do
   {:stdio, "<html>\n  <h1>\nShort2</h1>\n<p>\n<em>Short3</em></p>\n<!-- SPDX-License-Identifier: Apache-2.0 -->\n\n</html>\n"}
 
   """
-
+  @spec run(String.t() | [String.t()]) :: {:stdio, String.t()} | {:stderr, String.t()}
   def run(argv) do
     argv
     |> parse_args()

--- a/lib/earmark/error.ex
+++ b/lib/earmark/error.ex
@@ -4,6 +4,8 @@ defmodule Earmark.Error do
 
   defexception [:message]
 
+  @type t :: %__MODULE__{message: binary()}
+
   @doc false
   def exception(msg), do: %__MODULE__{message: msg}
 


### PR DESCRIPTION
commits by file
the different PRs don't overlap files, or if they do it was unintentional
The typespecs on this PR don't use Earmark.Options.options() type

At one point I had all the dialyzer errors gone #171