### PR TITLE
Remove Logger.debug

### DIFF
--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -260,10 +260,6 @@ defmodule Earmark.Parser.LineScanner do
   defp _create_list_item(match, indent, line)
 
   defp _create_list_item([_, bullet, spaces, text] = match, indent, line) do
-    Logger.debug(
-      "Creating list item: #{inspect(match)}, indent: #{inspect(indent)}, line: #{inspect(line)}"
-    )
-
     sl = byte_size(spaces)
     sl1 = if sl > 3, do: 1, else: sl + 1
     sl2 = sl1 + byte_size(bullet)


### PR DESCRIPTION
Hello!

Can we remove the `Logger.debug`? it's showing all the compiled lists on the logs.

I think it was included [here](https://github.com/pragdave/earmark/commit/db5e8b6b822e1793f21fbc637802372d6f49a1dd#diff-23f3a51773d305574af3c9b1c8f571a95f6c533e1502145ea086c1da8d2d7f43R263) for debugging, but it shouldn't be necessary now.