### PR TITLE
Tuple.append/2 is deprecated, use Tuple.insert_at/3 instead on Elixir 1.18

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -36,6 +36,10 @@ jobs:
             otp: 27
             os: ubuntu-latest
             warnings_as_errors: true
+          - elixir: 1.18.x
+            otp: 27
+            os: ubuntu-latest
+            warnings_as_errors: true
     env:
       MIX_ENV: test
     steps:

--- a/lib/earmark_parser/helpers/html_parser.ex
+++ b/lib/earmark_parser/helpers/html_parser.ex
@@ -1,17 +1,17 @@
 defmodule Earmark.Parser.Helpers.HtmlParser do
-
   @moduledoc false
 
   import Earmark.Parser.Helpers.StringHelpers, only: [behead: 2]
   import Earmark.Parser.LineScanner, only: [void_tag?: 1]
 
   def parse_html(lines)
-  def parse_html([tag_line|rest]) do
+
+  def parse_html([tag_line | rest]) do
     case _parse_tag(tag_line) do
-      { :ok, tag, "" }      -> [_parse_rest(rest, tag, [])]
-      { :ok, tag, suffix }  -> [_parse_rest(rest, tag, [suffix])]
-      { :ext, tag, "" }     -> [_parse_rest(rest, tag, [])]
-      { :ext, tag, suffix } -> [_parse_rest(rest, tag, []), [suffix]]
+      {:ok, tag, ""} -> [_parse_rest(rest, tag, [])]
+      {:ok, tag, suffix} -> [_parse_rest(rest, tag, [suffix])]
+      {:ext, tag, ""} -> [_parse_rest(rest, tag, [])]
+      {:ext, tag, suffix} -> [_parse_rest(rest, tag, []), [suffix]]
     end
   end
 
@@ -22,12 +22,15 @@ defmodule Earmark.Parser.Helpers.HtmlParser do
   @unquoted_attr ~r{\A ([-\w]+) (?: \s* = \s* ([^&\s>]*))? \s*}x
   defp _parse_atts(string, tag, atts) do
     case Regex.run(@quoted_attr, string) do
-      [all, name, _delim, value] -> _parse_atts(behead(string, all), tag, [{name, value}|atts])
-      _ -> case Regex.run(@unquoted_attr, string) do
-             [all, name, value] -> _parse_atts(behead(string, all), tag, [{name, value}|atts])
-             [all, name]        -> _parse_atts(behead(string, all), tag, [{name, name}|atts])
-             _                  -> _parse_tag_tail(string, tag, atts)
-      end
+      [all, name, _delim, value] ->
+        _parse_atts(behead(string, all), tag, [{name, value} | atts])
+
+      _ ->
+        case Regex.run(@unquoted_attr, string) do
+          [all, name, value] -> _parse_atts(behead(string, all), tag, [{name, value} | atts])
+          [all, name] -> _parse_atts(behead(string, all), tag, [{name, name} | atts])
+          _ -> _parse_tag_tail(string, tag, atts)
+        end
     end
   end
 
@@ -42,7 +45,7 @@ defmodule Earmark.Parser.Helpers.HtmlParser do
   @tag_tail ~r{\A .*? (/?)> \s* (.*) \z}x
   defp _parse_tag_tail(string, tag, atts) do
     case Regex.run(@tag_tail, string) do
-      [_, closing, suffix]  ->
+      [_, closing, suffix] ->
         suffix1 = String.replace(suffix, ~r{\s*</#{tag}>.*}, "")
         _close_tag_tail(tag, atts, closing != "", suffix1)
     end
@@ -50,9 +53,9 @@ defmodule Earmark.Parser.Helpers.HtmlParser do
 
   defp _close_tag_tail(tag, atts, closing?, suffix) do
     if closing? || void_tag?(tag) do
-      {:ext, {tag, Enum.reverse(atts)}, suffix }
+      {:ext, {tag, Enum.reverse(atts)}, suffix}
     else
-      {:ok, {tag, Enum.reverse(atts)}, suffix }
+      {:ok, {tag, Enum.reverse(atts)}, suffix}
     end
   end
 
@@ -61,18 +64,36 @@ defmodule Earmark.Parser.Helpers.HtmlParser do
 
   @verbatim %{verbatim: true}
   defp _parse_rest(rest, tag_tpl, lines)
+
   defp _parse_rest([], tag_tpl, lines) do
-    tag_tpl |> Tuple.append(Enum.reverse(lines)) |> Tuple.append(@verbatim)
-  end
-  defp _parse_rest([last_line], {tag, _}=tag_tpl, lines) do
-    case Regex.run(~r{\A\s*</#{tag}>\s*(.*)}, last_line) do
-      nil         -> tag_tpl |> Tuple.append(Enum.reverse([last_line|lines])) |> Tuple.append(@verbatim)
-      [_, ""]     -> tag_tpl |> Tuple.append(Enum.reverse(lines)) |> Tuple.append(@verbatim)
-      [_, suffix] -> [tag_tpl |> Tuple.append(Enum.reverse(lines)) |> Tuple.append(@verbatim), suffix]
-    end
-  end
-  defp _parse_rest([inner_line|rest], tag_tpl, lines) do
-    _parse_rest(rest, tag_tpl, [inner_line|lines])
+    tag_tpl
+    |> Tuple.insert_at(tuple_size(tag_tpl), Enum.reverse(lines))
+    |> Tuple.insert_at(tuple_size(tag_tpl) + 1, @verbatim)
   end
 
+  defp _parse_rest([last_line], {tag, _} = tag_tpl, lines) do
+    case Regex.run(~r{\A\s*</#{tag}>\s*(.*)}, last_line) do
+      nil ->
+        tag_tpl
+        |> Tuple.insert_at(tuple_size(tag_tpl), Enum.reverse([last_line | lines]))
+        |> Tuple.insert_at(tuple_size(tag_tpl) + 1, @verbatim)
+
+      [_, ""] ->
+        tag_tpl
+        |> Tuple.insert_at(tuple_size(tag_tpl), Enum.reverse(lines))
+        |> Tuple.insert_at(tuple_size(tag_tpl) + 1, @verbatim)
+
+      [_, suffix] ->
+        [
+          tag_tpl
+          |> Tuple.insert_at(tuple_size(tag_tpl), Enum.reverse(lines))
+          |> Tuple.insert_at(tuple_size(tag_tpl) + 1, @verbatim),
+          suffix
+        ]
+    end
+  end
+
+  defp _parse_rest([inner_line | rest], tag_tpl, lines) do
+    _parse_rest(rest, tag_tpl, [inner_line | lines])
+  end
 end


### PR DESCRIPTION
I found these deprecations and fixed them up. It looks like they were meant to be changed at some point from [this discussion](https://github.com/RobertDober/earmark_parser/issues/160), but the changes haven't made it in.

I also updated the action to test Elixir 1.18 as well since that is the version with the actual deprecation message.

Deprecation reference: [Elixir v1.18.0 released](https://elixirforum.com/t/elixir-v1-18-0-released/68248)