### PR TITLE
Prepare for OTP 28

### DIFF
--- a/lib/earmark_parser/ast/inline.ex
+++ b/lib/earmark_parser/ast/inline.ex
@@ -78,17 +78,19 @@ defmodule Earmark.Parser.Ast.Inline do
   #  Converters
   #
   ######################
-  @escape_rule ~r{^\\([\\`*\{\}\[\]()\#+\-.!_>])}
   def converter_for_escape({src, lnb, context, use_linky?}) do
-    if match = Regex.run(@escape_rule, src) do
+    escape_rule = ~r{^\\([\\`*\{\}\[\]()\#+\-.!_>])}
+
+    if match = Regex.run(escape_rule, src) do
       [match, escaped] = match
       {behead(src, match), lnb, prepend(context, escaped), use_linky?}
     end
   end
 
-  @autolink_rgx ~r{^<([^ >]+(@|:\/)[^ >]+)>}
   def converter_for_autolink({src, lnb, context, use_linky?}) do
-    if match = Regex.run(@autolink_rgx, src) do
+    autolink_rgx = ~r{^<([^ >]+(@|:\/)[^ >]+)>}
+
+    if match = Regex.run(autolink_rgx, src) do
       [match, link, protocol] = match
       {href, text} = convert_autolink(link, protocol)
       out = render_link(href, text)
@@ -126,11 +128,12 @@ defmodule Earmark.Parser.Ast.Inline do
     end
   end
 
-  @link_text ~S{(?:\[[^]]*\]|[^][]|\])*}
-  @reflink ~r{^!?\[(#{@link_text})\]\s*\[([^]]*)\]}x
   def converter_for_reflink({src, lnb, context, use_linky?}) do
+    link_text = ~S{(?:\[[^]]*\]|[^][]|\])*}
+    reflink = ~r{^!?\[(#{link_text})\]\s*\[([^]]*)\]}x
+
     if use_linky? do
-      if match = Regex.run(@reflink, src) do
+      if match = Regex.run(reflink, src) do
         {match_, alt_text, id} =
           case match do
             [match__, id, ""] -> {match__, id, id}
@@ -169,10 +172,11 @@ defmodule Earmark.Parser.Ast.Inline do
     end
   end
 
-  @nolink ~r{^!?\[((?:\[[^]]*\]|[^][])*)\]}
   def converter_for_nolink({src, lnb, context, use_linky?}) do
+    nolink = ~r{^!?\[((?:\[[^]]*\]|[^][])*)\]}
+
     if use_linky? do
-      case Regex.run(@nolink, src) do
+      case Regex.run(nolink, src) do
         [match, id] ->
           case reference_link(context, match, id, id, lnb) do
             {:ok, out} -> {behead(src, match), lnb, prepend(context, out), use_linky?}
@@ -188,71 +192,78 @@ defmodule Earmark.Parser.Ast.Inline do
   ################################
   # Simple Tags: em, strong, del #
   ################################
-  @strikethrough_rgx ~r{\A~~(?=\S)([\s\S]*?\S)~~}
   def converter_for_strikethrough_gfm({src, _, _, _} = conv_tuple) do
-    if match = Regex.run(@strikethrough_rgx, src) do
+    strikethrough_rgx = ~r{\A~~(?=\S)([\s\S]*?\S)~~}
+
+    if match = Regex.run(strikethrough_rgx, src) do
       _converter_for_simple_tag(conv_tuple, match, "del")
     end
   end
 
-  @strong_rgx ~r{\A__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)}
   def converter_for_strong({src, _, _, _} = conv_tuple) do
-    if match = Regex.run(@strong_rgx, src) do
+    strong_rgx = ~r{\A__([\s\S]+?)__(?!_)|^\*\*([\s\S]+?)\*\*(?!\*)}
+
+    if match = Regex.run(strong_rgx, src) do
       _converter_for_simple_tag(conv_tuple, match, "strong")
     end
   end
 
-  @emphasis_rgx ~r{\A\b_((?:__|[\s\S])+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)}
   def converter_for_em({src, _, _, _} = conv_tuple) do
-    if match = Regex.run(@emphasis_rgx, src) do
+    emphasis_rgx = ~r{\A\b_((?:__|[\s\S])+?)_\b|^\*((?:\*\*|[\s\S])+?)\*(?!\*)}
+
+    if match = Regex.run(emphasis_rgx, src) do
       _converter_for_simple_tag(conv_tuple, match, "em")
     end
   end
 
-  @sub_rgx ~r{\A~(?=\S)(.*?\S)~}
   def converter_for_sub({src, _, %{options: %{sub_sup: true}}, _} = conv_tuple) do
-    if match = Regex.run(@sub_rgx, src) do
+    sub_rgx = ~r{\A~(?=\S)(.*?\S)~}
+
+    if match = Regex.run(sub_rgx, src) do
       _converter_for_simple_tag(conv_tuple, match, "sub")
     end
   end
 
   def converter_for_sub(_), do: nil
 
-  @sup_rgx ~r{\A\^(?=\S)(.*?\S)\^}
   def converter_for_sup({src, _, %{options: %{sub_sup: true}}, _} = conv_tuple) do
-    if match = Regex.run(@sup_rgx, src) do
+    sup_rgx = ~r{\A\^(?=\S)(.*?\S)\^}
+
+    if match = Regex.run(sup_rgx, src) do
       _converter_for_simple_tag(conv_tuple, match, "sup")
     end
   end
 
   def converter_for_sup(_), do: nil
 
-  @squash_ws ~r{\s+}
-  @code ~r{^
-  (`+)		# $1 = Opening run of `
-  (.+?)		# $2 = The code block
-  (?<!`)
-  \1			# Matching closer
-  (?!`)
-}xs
   def converter_for_code({src, lnb, context, use_linky?}) do
-    if match = Regex.run(@code, src) do
+    squash_ws = ~r{\s+}
+
+    code = ~r{^
+      (`+)		# $1 = Opening run of `
+      (.+?)		# $2 = The code block
+      (?<!`)
+      \1			# Matching closer
+      (?!`)
+    }xs
+
+    if match = Regex.run(code, src) do
       [match, _, content] = match
       # Commonmark
       content1 =
         content
         |> String.trim()
-        |> String.replace(@squash_ws, " ")
+        |> String.replace(squash_ws, " ")
 
       out = codespan(content1)
       {behead(src, match), lnb, prepend(context, out), use_linky?}
     end
   end
 
-  @inline_ial ~r<^\s*\{:\s*(.*?)\s*}>
-
   def converter_for_inline_ial({src, lnb, context, use_linky?}) do
-    if match = Regex.run(@inline_ial, src) do
+    inline_ial = ~r<^\s*\{:\s*(.*?)\s*}>
+
+    if match = Regex.run(inline_ial, src) do
       [match, ial] = match
       {context1, ial_attrs} = parse_attrs(context, ial, lnb)
       new_tags = augment_tag_with_ial(context.value, ial_attrs, match)
@@ -267,15 +278,16 @@ defmodule Earmark.Parser.Ast.Inline do
     end
   end
 
-  @line_ending ~r{\r\n?|\n}
   @spec converter_for_text(conversion_data()) :: conversion_data()
   def converter_for_text({src, lnb, context, _}) do
+    line_ending = ~r{\r\n?|\n}
+
     matched =
       case Regex.run(context.rules.text, src) do
         [match] -> match
       end
 
-    line_count = matched |> String.split(@line_ending) |> Enum.count()
+    line_count = matched |> String.split(line_ending) |> Enum.count()
 
     ast = hard_line_breaks(matched, context.options.gfm)
     ast = walk_ast(ast, &gruber_line_breaks/1)
@@ -319,22 +331,24 @@ defmodule Earmark.Parser.Ast.Inline do
     {link, link}
   end
 
-  @gruber_line_break Regex.compile!(" {2,}(?>\n)", "m")
   defp gruber_line_breaks(text) do
+    gruber_line_break = ~r/ {2,}(?>\n)/m
+
     text
-    |> String.split(@gruber_line_break)
+    |> String.split(gruber_line_break)
     |> Enum.intersperse(emit("br"))
     |> _remove_leading_empty()
   end
 
-  @gfm_hard_line_break ~r{\\\n}
   defp hard_line_breaks(text, gfm)
   defp hard_line_breaks(text, false), do: text
   defp hard_line_breaks(text, nil), do: text
 
   defp hard_line_breaks(text, _) do
+    gfm_hard_line_break = ~r{\\\n}
+
     text
-    |> String.split(@gfm_hard_line_break)
+    |> String.split(gfm_hard_line_break)
     |> Enum.intersperse(emit("br"))
     |> _remove_leading_empty()
   end

--- a/lib/earmark_parser/ast/renderer/html_renderer.ex
+++ b/lib/earmark_parser/ast/renderer/html_renderer.ex
@@ -19,13 +19,13 @@ defmodule Earmark.Parser.Ast.Renderer.HtmlRenderer do
     tag_ = if annotation, do: annotate(tag, annotation), else: tag
     prepend(context, [tag_|rest])
   end
-  
-  @html_comment_start ~r{\A\s*<!--}
-  @html_comment_end ~r{-->.*\z}
-  def render_html_comment_line(line) do
-    line
-    |> String.replace(@html_comment_start, "")
-    |> String.replace(@html_comment_end, "")
-  end
 
+  def render_html_comment_line(line) do
+    html_comment_start = ~r{\A\s*<!--}
+    html_comment_end = ~r{-->.*\z}
+
+    line
+    |> String.replace(html_comment_start, "")
+    |> String.replace(html_comment_end, "")
+  end
 end

--- a/lib/earmark_parser/ast_renderer.ex
+++ b/lib/earmark_parser/ast_renderer.ex
@@ -152,16 +152,17 @@ defmodule Earmark.Parser.AstRenderer do
   #########
   # Lists #
   #########
-  @start_rgx ~r{\A\d+}
   defp render_block(
          %Block.List{type: type, bullet: bullet, blocks: items, attrs: attrs},
          context,
          _loose?
        ) do
+    start_rgx = ~r{\A\d+}
+
     context1 = render(items, clear_value(context))
 
     start_map =
-      case bullet && Regex.run(@start_rgx, bullet) do
+      case bullet && Regex.run(start_rgx, bullet) do
         nil -> %{}
         ["1"] -> %{}
         [start1] -> %{start: _normalize_start(start1)}

--- a/lib/earmark_parser/helpers.ex
+++ b/lib/earmark_parser/helpers.ex
@@ -8,7 +8,6 @@ defmodule Earmark.Parser.Helpers do
     Regex.replace(~r{(.*?)\t}, line, &expander/2)
   end
 
-  @trailing_ial_rgx ~r< (?<!^)(?'ial'{: \s* [^}]+ \s* }) \s* \z >x
   @doc ~S"""
   Returns a tuple containing a potentially present IAL and the line w/o the IAL
 
@@ -24,7 +23,8 @@ defmodule Earmark.Parser.Helpers do
       {nil, "{:.line-ial}"}
   """
   def extract_ial(line) do
-    case Regex.split(@trailing_ial_rgx, line, include_captures: true, parts: 2, on: [:ial]) do
+    regex = ~r< (?<!^)(?'ial'{: \s* [^}]+ \s* }) \s* \z >x
+    case Regex.split(regex, line, include_captures: true, parts: 2, on: [:ial]) do
       [_] -> {nil, line}
       [line_, "{:" <> ial, _] ->
         ial_ =
@@ -76,9 +76,11 @@ defmodule Earmark.Parser.Helpers do
    convert non-entity ampersands.
   """
 
-  @amp_rgx ~r{&(?!#?\w+;)}
+  def escape(html) do
+    regex = ~r{&(?!#?\w+;)}
 
-  def escape(html), do: _escape(Regex.replace(@amp_rgx, html, "&amp;"))
+    _escape(Regex.replace(regex, html, "&amp;"))
+  end
 
 
   defp _escape(html) do

--- a/lib/earmark_parser/helpers/ast_helpers.ex
+++ b/lib/earmark_parser/helpers/ast_helpers.ex
@@ -68,10 +68,11 @@ defmodule Earmark.Parser.Helpers.AstHelpers do
     lines |> Enum.join("\n")
   end
 
-  @remove_escapes ~r{ \\ (?! \\ ) }x
   @doc false
   def render_image(text, href, title) do
-    alt = text |> escape() |> String.replace(@remove_escapes, "")
+    regex = ~r{ \\ (?! \\ ) }x
+
+    alt = text |> escape() |> String.replace(regex, "")
 
     if title do
       emit("img", [], src: href, alt: alt, title: title)
@@ -89,10 +90,11 @@ defmodule Earmark.Parser.Helpers.AstHelpers do
   # add attributes to the outer tag in a block #
   ##############################################
 
-  @verbatims ~r<%[\da-f]{2}>i
   defp _encode(url) do
+    regex = ~r<%[\da-f]{2}>i
+
     url
-    |> String.split(@verbatims, include_captures: true)
+    |> String.split(regex, include_captures: true)
     |> Enum.chunk_every(2)
     |> Enum.map(&_encode_chunk/1)
     |> IO.chardata_to_string()

--- a/lib/earmark_parser/helpers/pure_link_helpers.ex
+++ b/lib/earmark_parser/helpers/pure_link_helpers.ex
@@ -3,18 +3,18 @@ defmodule Earmark.Parser.Helpers.PureLinkHelpers do
 
   import Earmark.Parser.Helpers.AstHelpers, only: [render_link: 2]
 
-  @pure_link_rgx ~r{
-    \A
-    (\s*)
-    (
-      (?:https?://|www\.)
-      [^\s<>]*
-      [^\s<>?!.,:*_~]
-    )
-  }ux
-
   def convert_pure_link(src) do
-    case Regex.run(@pure_link_rgx, src) do
+    pure_link_rgx = ~r{
+      \A
+      (\s*)
+      (
+        (?:https?://|www\.)
+        [^\s<>]*
+        [^\s<>?!.,:*_~]
+      )
+    }ux
+
+    case Regex.run(pure_link_rgx, src) do
       [_match, spaces, link_text] ->
         if String.ends_with?(link_text, ")") do
           remove_trailing_closing_parens(spaces, link_text)
@@ -27,9 +27,10 @@ defmodule Earmark.Parser.Helpers.PureLinkHelpers do
     end
   end
 
-  @split_at_ending_parens ~r{ (.*?) (\)*) \z}x
   defp remove_trailing_closing_parens(leading_spaces, link_text) do
-    [_, link_text, trailing_parens] = Regex.run(@split_at_ending_parens, link_text)
+    split_at_ending_parens = ~r{ (.*?) (\)*) \z}x
+
+    [_, link_text, trailing_parens] = Regex.run(split_at_ending_parens, link_text)
     trailing_paren_count = String.length(trailing_parens)
 
     # try to balance parens from the rhs

--- a/lib/earmark_parser/parser/link_parser.ex
+++ b/lib/earmark_parser/parser/link_parser.ex
@@ -102,18 +102,20 @@ defmodule Earmark.Parser.Parser.LinkParser do
     text
   end
 
-  # sic!!! Greedy and not context aware, matching '..." and "...' for backward comp
-  @title_rgx ~r{\A\s+(['"])(.*?)\1(?=\))}
   defp title(remaining_text) do
-    case Regex.run(@title_rgx, remaining_text) do
+    # sic!!! Greedy and not context aware, matching '..." and "...' for backward comp
+    title_rgx = ~r{\A\s+(['"])(.*?)\1(?=\))}
+
+    case Regex.run(title_rgx, remaining_text) do
       nil -> nil
       [parsed, _, inner] -> {parsed, inner}
     end
   end
 
-  @wikilink_rgx ~r{\A\[\[([^\]\|]+)(?:\|([^\]]+))?\]\]\Z}
   defp make_result(nil, _, parsed_text, :link) do
-    case Regex.run(@wikilink_rgx, parsed_text) do
+    wikilink_rgx = ~r{\A\[\[([^\]\|]+)(?:\|([^\]]+))?\]\]\Z}
+
+    case Regex.run(wikilink_rgx, parsed_text) do
       nil -> nil
       [_, wikilink] -> make_wikilink(parsed_text, wikilink, wikilink)
       [_, wikilink, link_text] -> make_wikilink(parsed_text, wikilink, link_text)

--- a/lib/earmark_parser/parser/list_parser.ex
+++ b/lib/earmark_parser/parser/list_parser.ex
@@ -182,9 +182,10 @@ defmodule Earmark.Parser.Parser.ListParser do
     %Block.List{loose?: loose?, type: type}
   end
 
-  @start_number_rgx ~r{\A0*(\d+)\.}
   defp _extract_start(%{bullet: bullet}) do
-    case Regex.run(@start_number_rgx, bullet) do
+    start_number_rgx = ~r{\A0*(\d+)\.}
+
+    case Regex.run(start_number_rgx, bullet) do
       nil -> ""
       [_, "1"] -> ""
       [_, start] -> ~s{ start="#{start}"}


### PR DESCRIPTION
OTP 28 is using a new regexp engine, PCRE2. Prior to OTP 28, Erlang regexps were using a binary:

```elixir
iex> ~r// |> Map.from_struct()
%{
  re_pattern: {:re_pattern, 0, 0, 0,
   <<69, 82, 67, 80, 71, 0, 0, 0, 0, 0, 0, 0, 1, 128, 0, 0, 255, 255, 255, 255,
     255, 255, 255, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 64, 0, 0, 0, 0, 0, 0, 0,
     0, 0, ...>>},
  opts: [],
  source: "",
  re_version: {"8.44 2020-02-12", :little}
}
```

Now it's:

```elixir
iex> ~r// |> Map.from_struct()
%{
  re_pattern: {:re_pattern, 0, 0, 0, #Reference<0.3488040677.452067330.62636>},
  opts: [],
  source: ""
}
```

Having reference as part of term is problematic, this now crashes during compilation:

```elixir
defmodule Main do
  @regexp ~r//

  def main do
    @regexp
  end
end
```

```
** (ArgumentError) cannot inject attribute @regexp into function/macro because cannot escape #Reference<0.3597165861.3136946177.250217>. The supported values are: lists, tuples, maps, atoms, numbers, bitstrings, PIDs and remote functions in the format &Mod.fun/arity
```
