### PR TITLE
Fix escape rgx_map for Otp 28

### DIFF
--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -40,34 +40,36 @@ defmodule Earmark.Parser.LineScanner do
         >
   '''x
 
-  @rgx_map %{
-    block_quote: ~r/\A>\s?(.*)/,
-    column_rgx: ~r{\A[\s|:-]+\z},
-    comment_rest: ~r/(<!--.*?-->)(.*)/,
-    fence: ~r/\A(\s*)(`{3,}|~{3,})\s*([^`\s]*)\s*\z/u,
-    footnote_definition: ~r/\A\[\^([^\s\]]+)\]:\s+(.*)/,
-    heading: ~r/^(\#{1,6})\s+(?|(.*?)\s*#*\s*$|(.*))/u,
-    html_close_tag: ~r/\A<\/([-\w]+?)>/,
-    html_comment_complete: ~r/\A <! (?: -- .*? -- \s* )+ > \z/x,
-    html_comment_start: ~r/\A <!-- .*? \z/x,
-    html_one_line: ~r{\A<([-\w]+?)(?:\s.*)?>.*</\1>},
-    html_open_tag: ~r/\A < ([-\w]+?) (?:\s.*)? >/x,
-    html_self_closing_tag: ~r{\A<([-\w]+?)(?:\s.*)?/>.*},
-    ial_definition: ~r<^{:(\s*[^}]+)}\s*$>,
-    id_re: @id_re,
-    indent_re: @indent_re,
-    list_item_ordered: ~r/^(\d{1,9}[.)])\s(\s*)(.*)/,
-    list_item_unordered: ~r/^([-*+])\s(\s*)(.*)/,
-    ruler_dash: ~r/^ (?:-\s?){3,} $/x,
-    ruler_star: ~r/^ (?:\*\s?){3,} $/x,
-    ruler_underscore: ~r/\A (?:_\s?){3,} \z/x,
-    setext_heading: ~r/^(=|-)+\s*$/,
-    table_line: ~r/^ \| (?: [^|]+ \|)+ \s* $ /x,
-    table_line_gfm: ~r/\A (\s*) .* \| /x,
-    table_line_prefix_space: ~r/\A (\s*) .* \s \| \s /x,
-    void_tag: @void_tag_rgx,
-    wiki_link: ~r/\[\[ .*? \]\]/x
-  }
+  defp rgx_map do
+    %{
+      block_quote: ~r/\A>\s?(.*)/,
+      column_rgx: ~r{\A[\s|:-]+\z},
+      comment_rest: ~r/(<!--.*?-->)(.*)/,
+      fence: ~r/\A(\s*)(`{3,}|~{3,})\s*([^`\s]*)\s*\z/u,
+      footnote_definition: ~r/\A\[\^([^\s\]]+)\]:\s+(.*)/,
+      heading: ~r/^(\#{1,6})\s+(?|(.*?)\s*#*\s*$|(.*))/u,
+      html_close_tag: ~r/\A<\/([-\w]+?)>/,
+      html_comment_complete: ~r/\A <! (?: -- .*? -- \s* )+ > \z/x,
+      html_comment_start: ~r/\A <!-- .*? \z/x,
+      html_one_line: ~r{\A<([-\w]+?)(?:\s.*)?>.*</\1>},
+      html_open_tag: ~r/\A < ([-\w]+?) (?:\s.*)? >/x,
+      html_self_closing_tag: ~r{\A<([-\w]+?)(?:\s.*)?/>.*},
+      ial_definition: ~r<^{:(\s*[^}]+)}\s*$>,
+      id_re: @id_re,
+      indent_re: @indent_re,
+      list_item_ordered: ~r/^(\d{1,9}[.)])\s(\s*)(.*)/,
+      list_item_unordered: ~r/^([-*+])\s(\s*)(.*)/,
+      ruler_dash: ~r/^ (?:-\s?){3,} $/x,
+      ruler_star: ~r/^ (?:\*\s?){3,} $/x,
+      ruler_underscore: ~r/\A (?:_\s?){3,} \z/x,
+      setext_heading: ~r/^(=|-)+\s*$/,
+      table_line: ~r/^ \| (?: [^|]+ \|)+ \s* $ /x,
+      table_line_gfm: ~r/\A (\s*) .* \| /x,
+      table_line_prefix_space: ~r/\A (\s*) .* \s \| \s /x,
+      void_tag: @void_tag_rgx,
+      wiki_link: ~r/\[\[ .*? \]\]/x
+    }
+  end
   @doc false
   def void_tag?(tag), do: Regex.match?(@void_tag_rgx, "<#{tag}>")
 
@@ -327,7 +329,7 @@ defmodule Earmark.Parser.LineScanner do
   defp regex_run(key, target), do: regex_run(key, target, [])
 
   defp regex_run(key, target, opts) do
-    @rgx_map
+    rgx_map()
     |> Map.get(key)
     |> Regex.run(target, opts)
   end
@@ -335,11 +337,12 @@ defmodule Earmark.Parser.LineScanner do
   defp table_line?(line), do: table_line?(line, :none)
 
   defp table_line?(line, opt) do
+    rgx_map = rgx_map()
     line
-    |> String.replace(@rgx_map.wiki_link, "")
+    |> String.replace(rgx_map.wiki_link, "")
     |> case do
-      line when opt in [:gfm] -> String.match?(line, @rgx_map.table_line_gfm)
-      _ -> String.match?(line, @rgx_map.table_line)
+      line when opt in [:gfm] -> String.match?(line, rgx_map.table_line_gfm)
+      _ -> String.match?(line, rgx_map.table_line)
     end
   end
 end


### PR DESCRIPTION
On Elixir 1.18.4 with Erlang/OTP 28 project fails to compile:
```
== Compilation error in file lib/earmark_parser/line_scanner.ex ==
** (ArgumentError) cannot inject attribute @rgx_map into function/macro because cannot escape #Reference<0.983345734.4272029698.15857>. The supported values are: lists, tuples, maps, atoms, numbers, bitstrings, PIDs and remote functions in the format &Mod.fun/arity
    (elixir 1.18.4) lib/kernel.ex:3777: Kernel.do_at_escape/2
    (elixir 1.18.4) expanding macro: Kernel.@/1
    lib/earmark_parser/line_scanner.ex:334: Earmark.Parser.LineScanner.regex_run/3
    (elixir 1.18.4) expanding macro: Kernel.|>/2
    lib/earmark_parser/line_scanner.ex:335: Earmark.Parser.LineScanner.regex_run/3
    (elixir 1.18.4) expanding macro: Kernel.|>/2
    lib/earmark_parser/line_scanner.ex:336: Earmark.Parser.LineScanner.regex_run/3
could not compile dependency :earmark, "mix compile" failed. Errors may have been logged above. You can recompile this dependency with "mix deps.compile earmark --force", update it with "mix deps.update earmark" or clean it with "mix deps.clean earmark"
``` 
This issue is similar to [this](https://github.com/ex-aws/ex_aws/issues/1142) and [this](https://github.com/leandrocp/req_embed/issues/11). 
This PR fixes that.