### PR TITLE
Support OTP/28 in CI

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,30 +14,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.14.x
-            otp: 25
+          - elixir: "1.14"
+            otp: "25"
             os: ubuntu-latest
             warnings_as_errors: true
-          - elixir: 1.15.x
-            otp: 25
+          - elixir: "1.15"
+            otp: "25"
             os: ubuntu-latest
             warnings_as_errors: true
-          - elixir: 1.16.x
-            otp: 26
+          - elixir: "1.16"
+            otp: "26"
             os: ubuntu-latest
             warnings_as_errors: true
-          - elixir: 1.17.x
-            otp: 27
+          - elixir: "1.17"
+            otp: "27"
             os: ubuntu-latest
             warnings_as_errors: true
-          - elixir: 1.18.x
-            otp: 27
+          - elixir: "1.18"
+            otp: "27"
+            os: ubuntu-latest
+            warnings_as_errors: true
+          - elixir: "1.18"
+            otp: "28"
             os: ubuntu-latest
             warnings_as_errors: true
     env:
       MIX_ENV: test
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - uses: erlef/setup-beam@v1
         with:
           otp-version: ${{matrix.otp}}
@@ -48,7 +52,7 @@ jobs:
           mix local.rebar --force
           mix deps.get --only test
       - name: Cache build artifacts
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.hex
@@ -80,4 +84,3 @@ jobs:
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
 # documentation.
-


### PR DESCRIPTION
Also, bump actions/checkout and actions/cache, and specify versions as strings and major versions, not numbers.