### PR TITLE
Fix typos

### DIFF
--- a/bench/simple_data_bench.exs
+++ b/bench/simple_data_bench.exs
@@ -147,8 +147,8 @@ defmodule Bench.SimpleDataBench do
   there are exterior bars.
 
   However in order to be more GFM compatible the `gfm_tables: true` option
-  can be used to interpret only interior vertical bars as a table if a seperation
-  line is given, therefor
+  can be used to interpret only interior vertical bars as a table if a separation
+  line is given, therefore
 
            Language|Rating
            --------|------
@@ -426,7 +426,7 @@ defmodule Bench.SimpleDataBench do
   **Rationale**:
 
   The AST is exposed in the spirit of [Floki's](https://hex.pm/packages/floki) there might be some subtle WS
-  differences and we chose to **always** have tripples, even for comments.
+  differences and we chose to **always** have triples, even for comments.
   We also do return a list for a single node
 
 

--- a/lib/earmark/ast_tools.ex
+++ b/lib/earmark/ast_tools.ex
@@ -5,7 +5,7 @@ defmodule Earmark.AstTools do
 
   @doc """
 
-  A helper to merge attributes in their cannonical representation
+  A helper to merge attributes in their canonical representation
 
 
       iex(1)> merge_atts([{"href", "url"}], target: "_blank")

--- a/lib/earmark/transform.ex
+++ b/lib/earmark/transform.ex
@@ -121,7 +121,7 @@ defmodule Earmark.Transform do
   is the quadtuples of the AST which are of the form `{tag, atts, content, meta}`
 
   All postprocessors can just be functions on nodes or a `TagSpecificProcessors` struct which will group
-  function applications depending on tags, as a convienience tuples of the form `{tag, function}` will be
+  function applications depending on tags, as a convenience tuples of the form `{tag, function}` will be
   transformed into a `TagSpecificProcessors` struct.
 
       iex(4)> add_class1 = &Earmark.AstTools.merge_atts_in_node(&1, class: "class1")
@@ -310,7 +310,7 @@ defmodule Earmark.Transform do
   end
 
   @doc ~S"""
-  This too is a structure perserving transformation but a value is passed to the mapping function as an accumulator, and the mapping
+  This too is a structure preserving transformation but a value is passed to the mapping function as an accumulator, and the mapping
   function needs to return the new node and the accumulator as a tuple, here is a simple example
 
       iex(14)> {:ok, ast, _} = Earmark.Parser.as_ast("- 1\n\n2\n- 3\n")
@@ -454,7 +454,7 @@ defmodule Earmark.Transform do
 
   defp escape(element, options)
 
-  defp escape("", _opions) do
+  defp escape("", _options) do
     []
   end
 
@@ -463,7 +463,7 @@ defmodule Earmark.Transform do
     # It doesn't seem possible to make _escape_to_iodata1
     # transform, for example, "--'" to "–‘" without
     # significantly complicating the code to the point
-    # it outweights the performance benefit.
+    # it outweighs the performance benefit.
     element =
       element
       |> replace(~r{(^|[-–—/\(\[\{"”“\s])'}, "\\1‘")
@@ -498,7 +498,7 @@ defmodule Earmark.Transform do
     |> Enum.take(level * indent)
   end
 
-  # Optimized HTML escaping + smartypants, insipred by Plug.HTML
+  # Optimized HTML escaping + smartypants, inspired by Plug.HTML
   # https://github.com/elixir-plug/plug/blob/v1.11.0/lib/plug/html.ex
 
   # Do not escape HTML entities

--- a/lib/earmark_parser.ex
+++ b/lib/earmark_parser.ex
@@ -328,7 +328,7 @@ defmodule Earmark.Parser do
 
   #### Lists
 
-  Lists are pretty much GFM compliant, but some behaviors concerning the interpreation of the markdown inside a List Item's first
+  Lists are pretty much GFM compliant, but some behaviors concerning the interpretation of the markdown inside a List Item's first
   paragraph seem not worth to be interpreted, examples are blockquote in a tight [list item](ttps://babelmark.github.io/?text=*+aa%0A++%3E+Second)
   which we can only have in a [loose one](https://babelmark.github.io/?text=*+aa%0A++%0A++%3E+Second)
 

--- a/lib/earmark_parser/helpers/lookahead_helpers.ex
+++ b/lib/earmark_parser/helpers/lookahead_helpers.ex
@@ -6,7 +6,7 @@ defmodule Earmark.Parser.Helpers.LookaheadHelpers do
   @doc """
   Indicates if the _numbered_line_ passed in leaves an inline code block open.
 
-  If so returns a tuple whre the first element is the opening sequence of backticks,
+  If so returns a tuple where the first element is the opening sequence of backticks,
   and the second the linenumber of the _numbered_line_
 
   Otherwise `{nil, 0}` is returned

--- a/lib/earmark_parser/options.ex
+++ b/lib/earmark_parser/options.ex
@@ -124,7 +124,7 @@ defmodule Earmark.Parser.Options do
 
   def normalize(options), do: struct(__MODULE__, options) |> normalize()
 
-  defp _deprecate_old_messages(opitons)
+  defp _deprecate_old_messages(options)
   defp _deprecate_old_messages(%__MODULE__{messages: %MapSet{}} = options), do: options
 
   defp _deprecate_old_messages(%__MODULE__{} = options) do

--- a/test/acceptance/html/compact_output_test.exs
+++ b/test/acceptance/html/compact_output_test.exs
@@ -19,7 +19,7 @@ defmodule Acceptance.Html.CompactModeTest do
      assert html == expected
    end
 
-   test "does not preserve newlines in paragraphes" do
+   test "does not preserve newlines in paragraphs" do
      expected = "<p>\nhello world</p>\n"
      result = Earmark.transform( [{"p", [], ["hello\nworld"], %{}}], compact_output: true)
 

--- a/test/acceptance/html/diverse_test.exs
+++ b/test/acceptance/html/diverse_test.exs
@@ -4,7 +4,7 @@ defmodule Acceptance.Html.DiverseTest do
   import ExUnit.CaptureIO
 
   describe "etc" do
-    test "entiy" do
+    test "entity" do
       markdown = "`f&ouml;&ouml;`\n"
       html     = "<p>\n<code class=\"inline\">f&amp;ouml;&amp;ouml;</code></p>\n"
       messages = []

--- a/test/acceptance/html/escape_test.exs
+++ b/test/acceptance/html/escape_test.exs
@@ -18,7 +18,7 @@ defmodule Acceptance.Html.EscapeTest do
       assert as_html(markdown, smartypants: false) == {:ok, html, messages}
     end
 
-    test "less obviously - escpe the escapes" do
+    test "less obviously - escape the escapes" do
       markdown = "\\\\` code`"
       html = "<p>\n\\<code class=\"inline\">code</code></p>\n"
       messages = []

--- a/test/acceptance/non_regression_test.exs
+++ b/test/acceptance/non_regression_test.exs
@@ -2,7 +2,7 @@ defmodule Acceptance.NonRegressionTest do
   use ExUnit.Case
   import Support.Performance, only: [convert_file: 2]
 
-  describe "Just assure that nothing really bad happenes when we convert some common Markdown" do
+  describe "Just assure that nothing really bad happened when we convert some common Markdown" do
     test "READMEs" do
       convert_file("elixir_readmes.md", :html)
     end

--- a/test/fixtures/elixir_hexdocs.md
+++ b/test/fixtures/elixir_hexdocs.md
@@ -1243,7 +1243,7 @@ strings also support the following escape characters:
 Note it is generally not advised to use `\xNN` in Elixir
 strings, as introducing an invalid byte sequence would
 make the string invalid. If you have to introduce a
-character by its hexdecimal representation, it is best
+character by its hexadecimal representation, it is best
 to work with Unicode code points, such as `\uNNNN`. In fact,
 understanding Unicode code points can be essential when doing
 low-level manipulations of string, so let's explore them in
@@ -1405,7 +1405,7 @@ a string by their hexadecimal code:
 
 Finally, to convert a String into a list of integers
 code points, usually known as "char lists", you can call
-`Strig.to_charlist`:
+`String.to_charlist`:
 
     iex> String.to_charlist("olá")
     [111, 108, 225]
@@ -1815,9 +1815,9 @@ for custom data types.
     * `:json` (default) - the regular JSON escaping as defined by RFC 7159.
     * `:javascript_safe` - additionally escapes the LINE SEPARATOR (U+2028)
       and PARAGRAPH SEPARATOR (U+2029) characters to make the produced JSON
-      valid JavaSciprt.
+      valid JavaScript.
     * `:html_safe` - similar to `:javascript`, but also escapes the `/`
-      caracter to prevent XSS.
+      character to prevent XSS.
     * `:unicode_safe` - escapes all non-ascii characters.
 
   * `:maps` - controls how maps are encoded. Possible values are:
@@ -1900,7 +1900,7 @@ Let's assume a presence of the following struct:
     end
 
 If we were to call `@derive Jason.Encoder` just before `defstruct`,
-an implementaion similar to the follwing implementation would be generated:
+an implementation similar to the following implementation would be generated:
 
     defimpl Jason.Encoder, for: Test do
       def encode(value, opts) do
@@ -1909,7 +1909,7 @@ an implementaion similar to the follwing implementation would be generated:
     end
 
 If we called `@derive {Jason.Encoder, only: [:foo]}`, an implementation
-similar to the following implementation would be genrated:
+similar to the following implementation would be generated:
 
     defimpl Jason.Encoder, for: Test do
       def encode(value, opts) do
@@ -2492,8 +2492,8 @@ Currently we assume there are always spaces around interior vertical unless
 there are exterior bars.
 
 However in order to be more GFM compatible the `gfm_tables: true` option
-can be used to interpret only interior vertical bars as a table if a seperation
-line is given, therefor
+can be used to interpret only interior vertical bars as a table if a separation
+line is given, therefore
 
      Language|Rating
      --------|------

--- a/test/fixtures/elixir_readmes.md
+++ b/test/fixtures/elixir_readmes.md
@@ -951,8 +951,8 @@ Currently we assume there are always spaces around interior vertical unless
 there are exterior bars.
 
 However in order to be more GFM compatible the `gfm_tables: true` option
-can be used to interpret only interior vertical bars as a table if a seperation
-line is given, therefor
+can be used to interpret only interior vertical bars as a table if a separation
+line is given, therefore
 
      Language|Rating
      --------|------
@@ -1187,7 +1187,7 @@ for the AST.
 **Rationale**:
 
 The AST is exposed in the spirit of [Floki's](https://hex.pm/packages/floki) there might be some subtle WS
-differences and we chose to **always** have tripples, even for comments.
+differences and we chose to **always** have triples, even for comments.
 We also do return a list for a single node
 
 

--- a/test/fixtures/medium.md
+++ b/test/fixtures/medium.md
@@ -123,7 +123,7 @@ Quote Level from the Text menu.
 
 Markdown supports ordered (numbered) and unordered (bulleted) lists.
 
-Unordered lists use asterisks, pluses, and hyphens -- interchangably
+Unordered lists use asterisks, pluses, and hyphens -- interchangeably
 -- as list markers:
 
 *   Red


### PR DESCRIPTION
Found via `codespell -S deps,README.md,RELEASE.md -L noo,searchin,fourty,symboll` and `typos --hidden --format brief`