### PR TITLE
Fix inline HTML comments being mishandled when inside backtick spans

### DIFF
--- a/lib/earmark_parser/ast/inline.ex
+++ b/lib/earmark_parser/ast/inline.ex
@@ -55,6 +55,7 @@ defmodule Earmark.Parser.Ast.Inline do
       converter_for_sup: &converter_for_sup/1,
       #
       converter_for_code: &converter_for_code/1,
+      converter_for_inline_comment: &converter_for_inline_comment/1,
       converter_for_br: &converter_for_br/1,
       converter_for_inline_ial: &converter_for_inline_ial/1,
       converter_for_pure_link: &converter_for_pure_link/1,
@@ -256,6 +257,17 @@ defmodule Earmark.Parser.Ast.Inline do
         |> String.replace(squash_ws, " ")
 
       out = codespan(content1)
+      {behead(src, match), lnb, prepend(context, out), use_linky?}
+    end
+  end
+
+  def converter_for_inline_comment({src, lnb, context, use_linky?}) do
+    comment_rgx = ~r/\A(<!--.*?-->)/s
+
+    if match = Regex.run(comment_rgx, src) do
+      [match, content] = match
+      inner = content |> String.replace_prefix("<!--", "") |> String.replace_suffix("-->", "")
+      out = {:comment, [], [inner], %{comment: true}}
       {behead(src, match), lnb, prepend(context, out), use_linky?}
     end
   end

--- a/lib/earmark_parser/line_scanner.ex
+++ b/lib/earmark_parser/line_scanner.ex
@@ -42,7 +42,6 @@ defmodule Earmark.Parser.LineScanner do
   # Converted rgx_map to a function
   defp rgx_map(:block_quote), do: ~r/\A>\s?(.*)/
   defp rgx_map(:column_rgx), do: ~r{\A[\s|:-]+\z}
-  defp rgx_map(:comment_rest), do: ~r/(<!--.*?-->)(.*)/
   defp rgx_map(:fence), do: ~r/\A(\s*)(`{3,}|~{3,})\s*([^`\s]*)\s*\z/u
   defp rgx_map(:footnote_definition), do: ~r/\A\[\^([^\s\]]+)\]:\s+(.*)/
   defp rgx_map(:heading), do: ~r/^(\#{1,6})\s+(?|(.*?)\s*#*\s*$|(.*))/u
@@ -296,22 +295,11 @@ defmodule Earmark.Parser.LineScanner do
   end
 
   defp _with_lookahead([line_lnb | lines], options, recursive) do
-    process_line(line_lnb, options, recursive) ++
+    [type_of(line_lnb, options, recursive)] ++
       _with_lookahead(lines, options, recursive)
   end
 
   defp _with_lookahead([], _options, _recursive), do: []
-
-  defp process_line({line, lnb}, options, recursive) do
-    case regex_run(:comment_rest, line, capture: :all_but_first) do
-      [comment, rest] ->
-        [type_of({comment, lnb}, options, recursive)] ++
-          [type_of({rest, lnb}, options, recursive)]
-
-      nil ->
-        [type_of({line, lnb}, options, recursive)]
-    end
-  end
 
   defp _determine_if_header(columns) do
     columns

--- a/test/regressions/i518_html_comment_in_backticks_test.exs
+++ b/test/regressions/i518_html_comment_in_backticks_test.exs
@@ -1,0 +1,16 @@
+defmodule Test.Regressions.I518HtmlCommentInBackticksTest do
+  use ExUnit.Case
+
+  test "HTML comment inside backticks is rendered as inline code" do
+    md = "some source `<!-- 2 -->`"
+    html = "<p>\nsome source <code class=\"inline\">&lt;!-- 2 --&gt;</code></p>\n"
+    assert Earmark.as_html(md) == {:ok, html, []}
+  end
+
+  test "HTML comment mid-line is rendered as a comment" do
+    md = "text <!-- comment --> more text"
+    html = "<p>\ntext <!-- comment -->\n more text</p>\n"
+    assert Earmark.as_html(md) == {:ok, html, []}
+  end
+end
+# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
The line scanner's `process_line` function used a regex to split any line containing `<!-- ... -->` into a block-level comment and trailing text, even when the comment appeared inside a backtick code span. This caused the backticks to be left unclosed and the comment to leak into the output.

Fix by removing `process_line` and the `comment_rest` regex entirely — block-level comments at the start of a line are already handled correctly by `html_comment_complete`/`html_comment_start` in `_type_of`. Add a new `converter_for_inline_comment` to the inline parser so that `<!-- ... -->` appearing inline in text is emitted as a proper comment node rather than being HTML-escaped.

Closes #518